### PR TITLE
fixed default value bug, added optional configurable defaults for cnra

### DIFF
--- a/ckanext/og_datatablesview/plugin/__init__.py
+++ b/ckanext/og_datatablesview/plugin/__init__.py
@@ -37,13 +37,13 @@ class OG_DataTablesView(MixinPlugin):
         template directory for the view
         '''
 
-        self.responsive_button_def = toolkit.aslist(
+        self.responsive_button_def = toolkit.asbool(
             config.get(u'ckan.datatables.view_table_responsive_default', False))
-        self.copy_print_buttons_def = toolkit.aslist(
+        self.copy_print_buttons_def = toolkit.asbool(
             config.get(u'ckan.datatables.view_table_displaycopyprint_default', False))
-        self.export_button_def = toolkit.aslist(
+        self.export_button_def = toolkit.asbool(
             config.get(u'ckan.datatables.view_table_displayexport_default', False))
-        self.col_reorder_def = toolkit.aslist(
+        self.col_reorder_def = toolkit.asbool(
             config.get(u'ckan.datatables.view_table_colreorder_default', True))
         
         # https://datatables.net/reference/option/lengthMenu

--- a/ckanext/og_datatablesview/plugin/__init__.py
+++ b/ckanext/og_datatablesview/plugin/__init__.py
@@ -38,13 +38,13 @@ class OG_DataTablesView(MixinPlugin):
         '''
 
         self.responsive_button_def = toolkit.aslist(
-            config.get(u'ckan_datatables_view_table_responsive_default', False))
+            config.get(u'ckan.datatables.view_table_responsive_default', False))
         self.copy_print_buttons_def = toolkit.aslist(
-            config.get(u'ckan_datatables_view_table_displaycopyprint_default', False))
+            config.get(u'ckan.datatables.view_table_displaycopyprint_default', False))
         self.export_button_def = toolkit.aslist(
-            config.get(u'ckan_datatables_view_table_displayexport_default', False))
+            config.get(u'ckan.datatables.view_table_displayexport_default', False))
         self.col_reorder_def = toolkit.aslist(
-            config.get(u'ckan_datatables_view_table_colreorder_default', True))
+            config.get(u'ckan.datatables.view_table_colreorder_default', True))
         
         # https://datatables.net/reference/option/lengthMenu
         self.page_length_choices = toolkit.aslist(

--- a/ckanext/og_datatablesview/plugin/__init__.py
+++ b/ckanext/og_datatablesview/plugin/__init__.py
@@ -37,6 +37,15 @@ class OG_DataTablesView(MixinPlugin):
         template directory for the view
         '''
 
+        self.responsive_button_def = toolkit.aslist(
+            config.get(u'ckan_datatables_view_table_responsive_default', False))
+        self.copy_print_buttons_def = toolkit.aslist(
+            config.get(u'ckan_datatables_view_table_displaycopyprint_default', False))
+        self.export_button_def = toolkit.aslist(
+            config.get(u'ckan_datatables_view_table_displayexport_default', False))
+        self.col_reorder_def = toolkit.aslist(
+            config.get(u'ckan_datatables_view_table_colreorder_default', True))
+        
         # https://datatables.net/reference/option/lengthMenu
         self.page_length_choices = toolkit.aslist(
             config.get(u'ckan.datatables.page_length_choices',
@@ -66,6 +75,10 @@ class OG_DataTablesView(MixinPlugin):
         return u'og_datatables/datatables_view.html'
 
     def form_template(self, context, data_dict):
+        data_dict['resource_view']['responsive_button_def'] = self.responsive_button_def
+        data_dict['resource_view']['copy_print_buttons_def'] = self.copy_print_buttons_def
+        data_dict['resource_view']['export_button_def'] = self.export_button_def
+        data_dict['resource_view']['col_reorder_def'] = self.col_reorder_def
         return u'og_datatables/datatables_form.html'
 
     def info(self):
@@ -80,7 +93,8 @@ class OG_DataTablesView(MixinPlugin):
                 u'responsive': [default(False), boolean_validator],
                 u'export_button': [default(False), boolean_validator],
                 u'copy_print_buttons': [default(False), boolean_validator],
-                u'col_reorder': [default(True), boolean_validator],
+                # We cannot use default(True) here, as the browser POSTs a null value when user unchecks the checkbox
+                u'col_reorder': [default(False), boolean_validator],
                 u'show_fields': [ignore_missing],
                 u'sort_column': [ignore_missing],
                 u'sort_order': [ignore_missing],

--- a/ckanext/og_datatablesview/templates/og_datatables/datatables_form.html
+++ b/ckanext/og_datatablesview/templates/og_datatables/datatables_form.html
@@ -4,25 +4,41 @@
     <label class="control-label">Table Options</label>
     <div class="controls">
         <label class="checkbox" for="field-responsive" title="Optimize table layout for smaller screen sizes">
-            <input id="field-responsive" type="checkbox" name="responsive" value="True" {{ "checked " if data.responsive }}>
+            {% if resource_view.id %}
+                <input id="field-responsive" type="checkbox" name="responsive" value="True" {{ "checked " if data.responsive }}>
+            {% else %}
+                <input id="field-responsive" type="checkbox" name="responsive" value="True" {{ "checked " if data.responsive_button_def }}>
+            {% endif %}
             Enable responsive display
         </label>
     </div>
     <div class="controls">
         <label class="checkbox" for="field-export_button" title="Display Export button">
-            <input id="field-export_button" type="checkbox" name="export_button" value="True" {{ "checked " if data.export_button }}>
+            {% if resource_view.id %}
+                <input id="field-export_button" type="checkbox" name="export_button" value="True" {{ "checked " if data.export_button }}>
+            {% else %}
+                <input id="field-export_button" type="checkbox" name="export_button" value="True" {{ "checked " if data.export_button_def }}>
+            {% endif %}
             Display Export button
         </label>
     </div>
     <div class="controls">
         <label class="checkbox" for="field-copy_print_buttons" title="Display Copy and Print buttons">
-            <input id="field-copy_print_buttons" type="checkbox" name="copy_print_buttons" value="True" {{ "checked " if data.copy_print_buttons }}>
+            {% if resource_view.id %}
+                <input id="field-copy_print_buttons" type="checkbox" name="copy_print_buttons" value="True" {{ "checked " if data.copy_print_buttons }}>
+            {% else %}
+                <input id="field-copy_print_buttons" type="checkbox" name="copy_print_buttons" value="True" {{ "checked " if data.copy_print_buttons_def }}>
+            {% endif %}
             Display Copy and Print buttons
         </label>
     </div>
     <div class="controls">
         <label class="checkbox" for="field-col_reorder" title="Allow users to reorder columns through a drag and drag operation">
-            <input id="field-col_reorder" type="checkbox" name="col_reorder" value="True" {{ "checked " if data.col_reorder }}>
+            {% if resource_view.id %}
+                <input id="field-col_reorder" type="checkbox" name="col_reorder" value="True" {{ "checked " if data.col_reorder }}>
+            {% else %}
+                <input id="field-col_reorder" type="checkbox" name="col_reorder" value="True" {{ "checked " if data.col_reorder_def }}>
+            {% endif %}
             Allow column reorder
         </label>
     </div>


### PR DESCRIPTION
<!--- Title Link to Jira Ticket - UPDATE WITH YOUR TICKET TAG in name and url --->
## [CRD-3094](https://opengovinc.atlassian.net/browse/CRD-3094) [CRD-3594](https://opengovinc.atlassian.net/browse/CRD-3594) [OD-2468](https://opengovinc.atlassian.net/browse/OD-2468)

## Description
This PR fixes a bug, where the "column reorder" option on Table View could not be disabled. When the user unchecks the option, the browser actually POSTs a null value, so using default(True) as a validator overrides the null posted with a true value.

This PR also adds optional configurable default values for all 4 options (responsive, copy print, export, column reorder), in case any customer wants to override the default value for their instance. When case there are no configuration overrides, the current behavior and values from previous versions of the code are kept, and this only applies to new views being created


## Submitter Checklist
- [x] The code looks good to me (LGTM)
- [x] I have tested the changes locally
- [x] The new changes does not affect web accessibility
