### PR TITLE
Fix typo when setting data-buttons

### DIFF
--- a/ckanext/og_datatablesview/templates/og_datatables/datatables_view.html
+++ b/ckanext/og_datatablesview/templates/og_datatables/datatables_view.html
@@ -52,7 +52,8 @@
             if resource_view.get('copy_print_buttons') else ''}}
         ]'
       {% else %}
-        data-buttons='[ {{ ', "copy", "print"' | safe
+        data-buttons='[
+          {{ '"copy", "print"' | safe
             if resource_view.get('copy_print_buttons') else ''}}
         ]'
       {% endif %}


### PR DESCRIPTION
# Description
Remove the extra comma when setting the data-buttons list. This fixes an issue where unexpected buttons may appear.