### PR TITLE
Fix display of column names containing periods

### DIFF
--- a/ckanext/og_datatablesview/assets/og_datatablesview.js
+++ b/ckanext/og_datatablesview/assets/og_datatablesview.js
@@ -345,7 +345,7 @@ this.ckan.module('og_datatables_view', function (jQuery) {
       }]
 
       gdataDict.forEach((colDefn, idx) => {
-        const colDict = { name: colDefn.id, data: colDefn.id, contentPadding: 'MM' }
+        const colDict = { name: colDefn['id'], data: colDefn['id'].replace('.', ''), contentPadding: 'MM' }
         switch (colDefn.type) {
           case 'numeric':
             colDict.type = 'num'

--- a/ckanext/og_datatablesview/blueprint.py
+++ b/ckanext/og_datatablesview/blueprint.py
@@ -124,8 +124,8 @@ def ajax(resource_view_id):
         data = []
         null_label = h.og_datatablesview_null_label()
         for row in response[u'records']:
-            record = {colname: escape(str(null_label if row.get(colname, u'')
-                                          is None else row.get(colname, u'')))
+            record = {colname.replace('.', ''): escape(str(null_label if row.get(colname, u'')
+                                                           is None else row.get(colname, u'')))
                       for colname in cols}
             # the DT_RowId is used in DT to set an element id for each record
             record['DT_RowId'] = 'row' + str(row.get(u'_id', u''))
@@ -133,9 +133,6 @@ def ajax(resource_view_id):
 
         dtdata = {
             u'draw': draw,
-            u'iTotalRecords': unfiltered_response.get(u'total', 0),
-            u'iTotalDisplayRecords': response.get(u'total', 0),
-            u'aaData': data,
             u'recordsTotal': unfiltered_response.get(u'total', 0),
             u'recordsFiltered': response.get(u'total', 0),
             u'data': data


### PR DESCRIPTION
# Description
Fix display of column names containing periods (i.e. `Dept. Descrptn`)