### PR TITLE
Fix export when _id column is hidden

### DIFF
--- a/ckanext/og_datatablesview/assets/vendor/DataTables/datatables.css
+++ b/ckanext/og_datatablesview/assets/vendor/DataTables/datatables.css
@@ -882,10 +882,6 @@ div.dataTables_scroll.dtfc-has-left table.table-bordered {
   border-left: none;
 }
 
-div.dataTables_scrollBody {
-  border-left: 1px solid #ddd !important;
-}
-
 div.dataTables_scrollFootInner table.table-bordered tr th:first-child,
 div.dataTables_scrollHeadInner table.table-bordered tr th:first-child {
   border-left: 1px solid #ddd !important;

--- a/ckanext/og_datatablesview/blueprint.py
+++ b/ckanext/og_datatablesview/blueprint.py
@@ -166,6 +166,8 @@ def filtered_download(resource_view_id):
 
     cols = [f[u'id'] for f in unfiltered_response[u'fields']]
     if u'show_fields' in resource_view:
+        if '_id' not in resource_view[u'show_fields']:
+            resource_view[u'show_fields'].insert(0, '_id')
         cols = [c for c in cols if c in resource_view[u'show_fields']]
 
     sort_list = []


### PR DESCRIPTION
## Description
This PR addresses an issue where exports are missing the first column when the `_id` column is hidden in the DataTables resource view configuration. The cause was the export logic filters out all columns that weren't explicitly shown, including the `_id` column which is required for proper data handling.

Also remove CSS for extra border from the table.