### PR TITLE
fix: remove &nbsp; from column header text for aria-label accessibility

### DIFF
--- a/ckanext/og_datatables_datefilterview/templates/og_datatables_datefilterview/datatables_view.html
+++ b/ckanext/og_datatables_datefilterview/templates/og_datatables_datefilterview/datatables_view.html
@@ -12,7 +12,6 @@
 
 {#- pass the datadictionary to javascript, so we can init columns there -#}
 {%- set datadictionary = h.og_datastore_dictionary(resource.id, resource_view.get('show_fields')) -%}
-{%- set nbspval = "&nbsp;"|safe -%}
 
 <script type=text/javascript>
     const gdataDict = {{ datadictionary|tojson }}
@@ -53,15 +52,15 @@
           {% if 'show_fields' not in resource_view or field.id in resource_view.show_fields -%}
             <th scope="col">
             {%- if data_dictionary_labels and field.info is defined and field.info.label|length -%}
-              {{ field.info.label|replace(" ", nbspval) }}
+              {{ field.info.label + " " }}
             {%- else -%}
-              {{ field.id|replace(" ", nbspval) }}
+              {{ field.id + " " }}
             {%- endif -%}
-            &nbsp;
             {%- if data_dictionary_labels and field.info is defined and (field.info.label|length or field.info.notes|length)-%}
               <i class="fa fa-info-circle" title="{{field.id}} ({{field.type}})&#10;{{ h.markdown_extract(field.info.notes, 300) }}"></i>
+              &nbsp;
             {%- endif -%}
-            &nbsp;</th>
+            </th>
           {%- endif %}
         {% endfor -%}
         <th id="_colspacer">colspacer</th>

--- a/ckanext/og_datatablesview/templates/og_datatables/datatables_view.html
+++ b/ckanext/og_datatablesview/templates/og_datatables/datatables_view.html
@@ -12,7 +12,6 @@
 
 {#- pass the datadictionary to javascript, so we can init columns there -#}
 {%- set datadictionary = h.og_datastore_dictionary(resource.id, resource_view.get('show_fields')) -%}
-{%- set nbspval = "&nbsp;"|safe -%}
 
 <script type=text/javascript>
     const gdataDict = {{ datadictionary|tojson }}
@@ -53,15 +52,15 @@
           {% if 'show_fields' not in resource_view or field.id in resource_view.show_fields -%}
             <th scope="col">
             {%- if data_dictionary_labels and field.info is defined and field.info.label|length -%}
-              {{ field.info.label|replace(" ", nbspval) }}
+              {{ field.info.label + " " }}
             {%- else -%}
-              {{ field.id|replace(" ", nbspval) }}
+              {{ field.id + " " }}
             {%- endif -%}
-            &nbsp;
             {%- if data_dictionary_labels and field.info is defined and (field.info.label|length or field.info.notes|length)-%}
               <i class="fa fa-info-circle" title="{{field.id}} ({{field.type}})&#10;{{ h.markdown_extract(field.info.notes, 300) }}"></i>
+              &nbsp;
             {%- endif -%}
-            &nbsp;</th>
+            </th>
           {%- endif %}
         {% endfor -%}
         <th id="_colspacer">colspacer</th>


### PR DESCRIPTION
# Description
Column headers in DataTable views were replacing spaces in column names with the string `&nbsp;`. DataTables derives the aria-label for sort buttons from the <th> content by stripping HTML tags but does not decode HTML entities.

As a result, the generated aria-label values contained literal `&nbsp;` strings (for example: `Column&nbsp;Name&nbsp;&nbsp;: activate to sort column ascending`). Screen readers would read these literally as “ampersand n b s p semicolon” instead of interpreting them as spaces.

### Changes
- Removed nbspval variable
- Changed to {{ field.info.label + " " }} and {{ field.id + " " }} (adds regular space)
- Moved `&nbsp;` to only appear after the info icon (when present)