### PR TITLE
Support MM/DD/YYYY date format in timestamp column searches

### DIFF
--- a/ckanext/og_datatables_datefilterview/assets/og_datatables_datefilterview.js
+++ b/ckanext/og_datatables_datefilterview/assets/og_datatables_datefilterview.js
@@ -466,7 +466,15 @@ this.ckan.module('og_datatables_datefilter_view', function (jQuery) {
         const colname = thecol.textContent
         const colid = 'dtcol-' + validateId(colname) + '-' + i
         const coltype = $(thecol).data('type')
-        const placeholderText = formatdateflag && coltype.substr(0, 9) === 'timestamp' ? ' placeholder="yyyy-mm-dd"' : ''
+        let placeholderText = ''
+        if (formatdateflag && coltype.substr(0, 9) === 'timestamp') {
+          // Set placeholder based on configured date format
+          if (dateformat.toUpperCase() === 'MM/DD/YYYY') {
+            placeholderText = ' placeholder="mm/dd/yyyy"'
+          } else {
+            placeholderText = ' placeholder="yyyy-mm-dd"'
+          }
+        }
         const ariaLabelAttr = colname ? ' aria-label="' + that._('Search') + ' ' + colname + '"' : ''
         $('<input id="' + colid + '" name="' + colid + '" autosave="' + colid + '"' +
                 placeholderText +

--- a/ckanext/og_datatables_datefilterview/blueprint.py
+++ b/ckanext/og_datatables_datefilterview/blueprint.py
@@ -50,14 +50,16 @@ def is_date_range_filter(value):
     - "2024-01-01 to 2024-12-31"
     - "2024-01-01,2024-12-31"
     - "2024-01-01 - 2024-12-31"
-    
+    - "01/15/2024 to 12/31/2024"
+
+    Dates are normalized to YYYY-MM-DD format for SQL queries.
     Returns tuple (is_date_range, start_date, end_date) or (False, None, None)
     '''
     if not value:
         return (False, None, None)
-    
+
     value = value.strip()
-    
+
     # Try "to" separator
     if u' to ' in value.lower():
         parts = re.split(r'\s+to\s+', value, flags=re.IGNORECASE)
@@ -65,8 +67,9 @@ def is_date_range_filter(value):
             start_date = parts[0].strip()
             end_date = parts[1].strip()
             if _is_valid_date(start_date) and _is_valid_date(end_date):
-                return (True, start_date, end_date)
-    
+                # Normalize dates to YYYY-MM-DD format
+                return (True, _normalize_date(start_date), _normalize_date(end_date))
+
     # Try comma separator
     if u',' in value:
         parts = value.split(u',')
@@ -74,8 +77,9 @@ def is_date_range_filter(value):
             start_date = parts[0].strip()
             end_date = parts[1].strip()
             if _is_valid_date(start_date) and _is_valid_date(end_date):
-                return (True, start_date, end_date)
-    
+                # Normalize dates to YYYY-MM-DD format
+                return (True, _normalize_date(start_date), _normalize_date(end_date))
+
     # Try dash separator (with spaces)
     if u' - ' in value:
         parts = value.split(u' - ')
@@ -83,20 +87,56 @@ def is_date_range_filter(value):
             start_date = parts[0].strip()
             end_date = parts[1].strip()
             if _is_valid_date(start_date) and _is_valid_date(end_date):
-                return (True, start_date, end_date)
-    
+                # Normalize dates to YYYY-MM-DD format
+                return (True, _normalize_date(start_date), _normalize_date(end_date))
+
     return (False, None, None)
 
 
 def _is_valid_date(date_str):
     u'''
-    Check if a string is a valid date in YYYY-MM-DD format.
+    Check if a string is a valid date in YYYY-MM-DD or MM/DD/YYYY format.
+    Returns True if valid, False otherwise.
     '''
+    # Try YYYY-MM-DD format
     try:
         datetime.strptime(date_str, u'%Y-%m-%d')
         return True
     except ValueError:
-        return False
+        pass
+
+    # Try MM/DD/YYYY format
+    try:
+        datetime.strptime(date_str, u'%m/%d/%Y')
+        return True
+    except ValueError:
+        pass
+
+    return False
+
+
+def _normalize_date(date_str):
+    u'''
+    Convert a date string to YYYY-MM-DD format.
+    Accepts both YYYY-MM-DD and MM/DD/YYYY formats.
+    Returns the normalized date string in YYYY-MM-DD format.
+    '''
+    # Try YYYY-MM-DD format first (already normalized)
+    try:
+        parsed_date = datetime.strptime(date_str, u'%Y-%m-%d')
+        return date_str
+    except ValueError:
+        pass
+
+    # Try MM/DD/YYYY format and convert to YYYY-MM-DD
+    try:
+        parsed_date = datetime.strptime(date_str, u'%m/%d/%Y')
+        return parsed_date.strftime(u'%Y-%m-%d')
+    except ValueError:
+        pass
+
+    # If neither format works, return the original string
+    return date_str
 
 
 def is_date_column(column_name, fields):
@@ -303,6 +343,19 @@ def ajax(resource_view_id):
                         else:
                             del filters[filter_key]
                         break
+                    elif is_date_column(filter_key, unfiltered_response[u'fields']) and _is_valid_date(str(filter_value).strip()):
+                        # Single date search in timestamp column - treat as date range for same day
+                        normalized_date = _normalize_date(str(filter_value).strip())
+                        date_range_filter = (normalized_date, normalized_date)
+                        date_range_column = filter_key
+                        # Remove from regular filters (it will be handled by SQL query)
+                        if isinstance(filters[filter_key], list):
+                            filters[filter_key] = [v for v in filters[filter_key] if v != filter_value]
+                            if not filters[filter_key]:
+                                del filters[filter_key]
+                        else:
+                            del filters[filter_key]
+                        break
             if date_range_filter:
                 break
     
@@ -319,6 +372,11 @@ def ajax(resource_view_id):
                 if is_date_range and is_date_column(k, unfiltered_response[u'fields']):
                     # Store date range filter info
                     date_range_filter = (start_date, end_date)
+                    date_range_column = k
+                elif is_date_column(k, unfiltered_response[u'fields']) and _is_valid_date(v.strip()):
+                    # Single date search in timestamp column - treat as date range for same day
+                    normalized_date = _normalize_date(v.strip())
+                    date_range_filter = (normalized_date, normalized_date)
                     date_range_column = k
                 else:
                     # replace non-alphanumeric characters with FTS wildcard (_)
@@ -451,39 +509,73 @@ def filtered_download(resource_view_id):
 
     colsearch_dict = {}
     columns = params[u'columns']
+    date_range_filter = None
+    date_range_column = None
+
     for column in columns:
         if column[u'search'][u'value']:
             v = column[u'search'][u'value']
             if v:
                 k = column[u'name']
-                # replace non-alphanumeric characters with FTS wildcard (_)
-                v = re.sub(r'[^0-9a-zA-Z\-]+', '_', v)
-                # append ':*' so we can do partial FTS searches
-                colsearch_dict[k] = v + u':*'
-
-    # Check for date range filters
-    date_range_filter = None
-    date_range_column = None
-    filters_for_query = {}
-    
-    for filter_key, filter_values in filters.items():
-        if filter_values:
-            # Handle both single value and list of values
-            values_to_check = filter_values if isinstance(filter_values, list) else [filter_values]
-            has_date_range = False
-            for filter_value in values_to_check:
-                if filter_value:
-                    # Check if this is a date range filter
-                    is_date_range, start_date, end_date = is_date_range_filter(str(filter_value))
-                    if is_date_range and is_date_column(filter_key, unfiltered_response[u'fields']):
+                # Check if this is a date filter in a timestamp column
+                if not date_range_filter:
+                    is_date_range, start_date, end_date = is_date_range_filter(v)
+                    if is_date_range and is_date_column(k, unfiltered_response[u'fields']):
                         # Store date range filter info
                         date_range_filter = (start_date, end_date)
-                        date_range_column = filter_key
-                        has_date_range = True
-                        break
-            
-            # Add to filters_for_query if not a date range
-            if not has_date_range:
+                        date_range_column = k
+                    elif is_date_column(k, unfiltered_response[u'fields']) and _is_valid_date(v.strip()):
+                        # Single date search in timestamp column - treat as date range for same day
+                        normalized_date = _normalize_date(v.strip())
+                        date_range_filter = (normalized_date, normalized_date)
+                        date_range_column = k
+                    else:
+                        # replace non-alphanumeric characters with FTS wildcard (_)
+                        v = re.sub(r'[^0-9a-zA-Z\-]+', '_', v)
+                        # append ':*' so we can do partial FTS searches
+                        colsearch_dict[k] = v + u':*'
+                else:
+                    # Date range already found, skip date columns
+                    if not (is_date_column(k, unfiltered_response[u'fields'])):
+                        # replace non-alphanumeric characters with FTS wildcard (_)
+                        v = re.sub(r'[^0-9a-zA-Z\-]+', '_', v)
+                        # append ':*' so we can do partial FTS searches
+                        colsearch_dict[k] = v + u':*'
+
+    # Check for date range filters from URL parameters (only if not already found from column search)
+    filters_for_query = {}
+
+    if not date_range_filter:
+        for filter_key, filter_values in filters.items():
+            if filter_values:
+                # Handle both single value and list of values
+                values_to_check = filter_values if isinstance(filter_values, list) else [filter_values]
+                has_date_range = False
+                for filter_value in values_to_check:
+                    if filter_value:
+                        # Check if this is a date range filter
+                        is_date_range, start_date, end_date = is_date_range_filter(str(filter_value))
+                        if is_date_range and is_date_column(filter_key, unfiltered_response[u'fields']):
+                            # Store date range filter info
+                            date_range_filter = (start_date, end_date)
+                            date_range_column = filter_key
+                            has_date_range = True
+                            break
+                        elif is_date_column(filter_key, unfiltered_response[u'fields']) and _is_valid_date(str(filter_value).strip()):
+                            # Single date search in timestamp column - treat as date range for same day
+                            normalized_date = _normalize_date(str(filter_value).strip())
+                            date_range_filter = (normalized_date, normalized_date)
+                            date_range_column = filter_key
+                            has_date_range = True
+                            break
+
+                # Add to filters_for_query if not a date range
+                if not has_date_range:
+                    filters_for_query[filter_key] = filter_values
+    else:
+        # Date range already found from column search, just copy non-date filters
+        for filter_key, filter_values in filters.items():
+            if not is_date_column(filter_key, unfiltered_response[u'fields']):
                 filters_for_query[filter_key] = filter_values
     
     # If we have a date range filter, use SQL query for export

--- a/ckanext/og_datatables_datefilterview/tests/__init__.py
+++ b/ckanext/og_datatables_datefilterview/tests/__init__.py
@@ -1,0 +1,1 @@
+# encoding: utf-8

--- a/ckanext/og_datatables_datefilterview/tests/test_date_filters.py
+++ b/ckanext/og_datatables_datefilterview/tests/test_date_filters.py
@@ -1,0 +1,211 @@
+# encoding: utf-8
+import pytest
+
+from ckanext.og_datatables_datefilterview.blueprint import (
+    _is_valid_date,
+    _normalize_date,
+    is_date_range_filter,
+    is_date_column
+)
+
+
+class TestIsValidDate:
+    """Tests for _is_valid_date function"""
+
+    def test_valid_date_yyyy_mm_dd(self):
+        assert _is_valid_date('2024-01-15') == True
+
+    def test_valid_date_mm_dd_yyyy(self):
+        assert _is_valid_date('01/15/2024') == True
+
+    def test_valid_date_end_of_year(self):
+        assert _is_valid_date('2024-12-31') == True
+        assert _is_valid_date('12/31/2024') == True
+
+    def test_valid_date_leap_year(self):
+        assert _is_valid_date('2024-02-29') == True
+        assert _is_valid_date('02/29/2024') == True
+
+    def test_invalid_date_not_leap_year(self):
+        assert _is_valid_date('2023-02-29') == False
+        assert _is_valid_date('02/29/2023') == False
+
+    def test_invalid_date_month_too_high(self):
+        assert _is_valid_date('2024-13-01') == False
+        assert _is_valid_date('13/01/2024') == False
+
+    def test_invalid_date_day_too_high(self):
+        assert _is_valid_date('2024-01-32') == False
+        assert _is_valid_date('01/32/2024') == False
+
+    def test_invalid_date_format(self):
+        assert _is_valid_date('invalid') == False
+        assert _is_valid_date('2024/01/15') == False
+        assert _is_valid_date('01-15-2024') == False
+
+    def test_invalid_date_empty_string(self):
+        assert _is_valid_date('') == False
+
+
+class TestNormalizeDate:
+    """Tests for _normalize_date function"""
+
+    def test_normalize_yyyy_mm_dd(self):
+        assert _normalize_date('2024-01-15') == '2024-01-15'
+
+    def test_normalize_mm_dd_yyyy(self):
+        assert _normalize_date('01/15/2024') == '2024-01-15'
+
+    def test_normalize_end_of_year(self):
+        assert _normalize_date('12/31/2024') == '2024-12-31'
+        assert _normalize_date('2024-12-31') == '2024-12-31'
+
+    def test_normalize_leap_year(self):
+        assert _normalize_date('02/29/2024') == '2024-02-29'
+
+    def test_normalize_single_digit_month_day(self):
+        assert _normalize_date('01/05/2024') == '2024-01-05'
+
+    def test_normalize_invalid_date_returns_original(self):
+        assert _normalize_date('invalid') == 'invalid'
+        assert _normalize_date('13/32/2024') == '13/32/2024'
+
+    def test_normalize_empty_string(self):
+        assert _normalize_date('') == ''
+
+
+class TestIsDateRangeFilter:
+    """Tests for is_date_range_filter function"""
+
+    def test_date_range_with_to_separator_yyyy_mm_dd(self):
+        is_range, start, end = is_date_range_filter('2024-01-01 to 2024-12-31')
+        assert is_range == True
+        assert start == '2024-01-01'
+        assert end == '2024-12-31'
+
+    def test_date_range_with_to_separator_mm_dd_yyyy(self):
+        is_range, start, end = is_date_range_filter('01/01/2024 to 12/31/2024')
+        assert is_range == True
+        assert start == '2024-01-01'
+        assert end == '2024-12-31'
+
+    def test_date_range_with_to_case_insensitive(self):
+        is_range, start, end = is_date_range_filter('01/01/2024 TO 12/31/2024')
+        assert is_range == True
+        assert start == '2024-01-01'
+        assert end == '2024-12-31'
+
+    def test_date_range_with_comma_separator(self):
+        is_range, start, end = is_date_range_filter('2024-01-01,2024-12-31')
+        assert is_range == True
+        assert start == '2024-01-01'
+        assert end == '2024-12-31'
+
+    def test_date_range_with_dash_separator(self):
+        is_range, start, end = is_date_range_filter('2024-01-01 - 2024-12-31')
+        assert is_range == True
+        assert start == '2024-01-01'
+        assert end == '2024-12-31'
+
+    def test_date_range_normalizes_mm_dd_yyyy(self):
+        is_range, start, end = is_date_range_filter('01/15/2024 to 03/20/2024')
+        assert is_range == True
+        assert start == '2024-01-15'
+        assert end == '2024-03-20'
+
+    def test_single_date_not_a_range(self):
+        is_range, start, end = is_date_range_filter('2024-01-15')
+        assert is_range == False
+        assert start is None
+        assert end is None
+
+    def test_invalid_date_range(self):
+        is_range, start, end = is_date_range_filter('2024-13-01 to 2024-14-31')
+        assert is_range == False
+
+    def test_empty_string(self):
+        is_range, start, end = is_date_range_filter('')
+        assert is_range == False
+        assert start is None
+        assert end is None
+
+    def test_date_range_with_extra_spaces(self):
+        is_range, start, end = is_date_range_filter('  2024-01-01  to  2024-12-31  ')
+        assert is_range == True
+        assert start == '2024-01-01'
+        assert end == '2024-12-31'
+
+
+class TestIsDateColumn:
+    """Tests for is_date_column function"""
+
+    def test_timestamp_column(self):
+        fields = [
+            {'id': 'created_date', 'type': 'timestamp'},
+            {'id': 'name', 'type': 'text'}
+        ]
+        assert is_date_column('created_date', fields) == True
+
+    def test_timestamptz_column(self):
+        fields = [
+            {'id': 'modified_at', 'type': 'timestamptz'},
+            {'id': 'name', 'type': 'text'}
+        ]
+        assert is_date_column('modified_at', fields) == True
+
+    def test_date_column(self):
+        fields = [
+            {'id': 'birth_date', 'type': 'date'},
+            {'id': 'name', 'type': 'text'}
+        ]
+        assert is_date_column('birth_date', fields) == True
+
+    def test_non_date_column(self):
+        fields = [
+            {'id': 'name', 'type': 'text'},
+            {'id': 'age', 'type': 'numeric'}
+        ]
+        assert is_date_column('name', fields) == False
+        assert is_date_column('age', fields) == False
+
+    def test_column_not_in_fields(self):
+        fields = [
+            {'id': 'name', 'type': 'text'}
+        ]
+        assert is_date_column('missing_column', fields) == False
+
+    def test_empty_fields(self):
+        assert is_date_column('any_column', []) == False
+
+    def test_case_sensitivity(self):
+        fields = [
+            {'id': 'created_date', 'type': 'TIMESTAMP'}
+        ]
+        # Type comparison is case-insensitive
+        assert is_date_column('created_date', fields) == True
+
+
+class TestDateFormatIntegration:
+    """Integration tests for date format handling"""
+
+    def test_mm_dd_yyyy_converts_to_normalized_range(self):
+        # Test that MM/DD/YYYY format is properly validated and normalized
+        date_str = '01/15/2024'
+        assert _is_valid_date(date_str) == True
+        normalized = _normalize_date(date_str)
+        assert normalized == '2024-01-15'
+
+    def test_range_with_mixed_valid_formats_same_type(self):
+        # Both dates in same format should work
+        is_range, start, end = is_date_range_filter('01/01/2024 to 12/31/2024')
+        assert is_range == True
+        # Both should be normalized
+        assert start == '2024-01-01'
+        assert end == '2024-12-31'
+
+    def test_yyyy_mm_dd_stays_normalized(self):
+        # YYYY-MM-DD format should remain unchanged
+        date_str = '2024-01-15'
+        assert _is_valid_date(date_str) == True
+        normalized = _normalize_date(date_str)
+        assert normalized == '2024-01-15'


### PR DESCRIPTION
# Description
This PR adds support for MM/DD/YYYY date format in timestamp column searches, while maintaining backward compatibility with YYYY-MM-DD format.

  Changes

  - Date format validation: Now accepts both YYYY-MM-DD and MM/DD/YYYY formats
  - Single date searches: Users can search timestamp columns using either 01/15/2024 or 2024-01-15
  - Date range searches: Supports ranges in both formats (e.g., 01/01/2024 to 12/31/2024)
  - Dynamic placeholders: Placeholder text adapts based on ckan.datatables.date_format config
    - If set to MM/DD/YYYY: shows "mm/dd/yyyy"
    - Otherwise: shows "yyyy-mm-dd"

  Technical Details

  - Added _normalize_date() function to convert MM/DD/YYYY to YYYY-MM-DD for SQL queries
  - Enhanced _is_valid_date() to validate both formats
  - Single date searches are converted to same-day date ranges for accurate timestamp filtering

  All changes are backward compatible. Existing YYYY-MM-DD searches continue to work as before.