### PR TITLE
fix: support null value in filters

### DIFF
--- a/ckanext/og_datatablesview/blueprint.py
+++ b/ckanext/og_datatablesview/blueprint.py
@@ -2,15 +2,23 @@
 
 from urllib.parse import urlencode
 from html import escape
+from itertools import chain
+import csv
+import io
 
-from flask import Blueprint
+from flask import Blueprint, Response
 
 
 from ckan.common import json
-from ckan.plugins.toolkit import get_action, request, h
+from ckan.plugins.toolkit import get_action, request, h, abort
+from ckanext.datastore.writer import xml_writer
 import re
 
 ogdatatablesview = Blueprint(u'ogdatatablesview', __name__)
+
+# Page size used when streaming a null-filter export, matching CKAN's
+# datastore dump (ckanext.datastore.blueprint.PAGINATE_BY).
+EXPORT_PAGINATE_BY = 32000
 
 
 def format_fts_query(search_value):
@@ -75,6 +83,217 @@ def merge_filters(view_filters, user_filters_str):
     return filters
 
 
+def _quote_identifier(name):
+    u'''Quote an identifier (column/table name) for SQL, escaping any
+    embedded double quotes and stripping NUL bytes (mirrors CKAN's
+    ckanext.datastore.backend.postgres.identifier).'''
+    return u'"{}"'.format(str(name).replace(u'"', u'""').replace(u'\0', u''))
+
+
+def _quote_literal(value):
+    u'''Quote a string literal for SQL, escaping any embedded single
+    quotes and stripping NUL bytes (mirrors CKAN's
+    ckanext.datastore.backend.postgres.literal_string).'''
+    return u"'{}'".format(str(value).replace(u"'", u"''").replace(u'\0', u''))
+
+
+def build_filter_where_fragments(filters):
+    u'''
+    Split merged filters into SQL WHERE fragments.
+
+    A filter whose value list contains an empty string is treated as a
+    "null" filter (the Add Filter dropdown encodes the null option as an
+    empty value). Those are turned into ``IS NULL OR = ''`` clauses so they
+    match SQL NULLs, which the standard datastore_search filters never do.
+
+    Returns a tuple ``(null_clauses, regular_clauses)`` of SQL fragment
+    strings (no leading ``AND``). Null clauses are parenthesised because
+    they contain ``OR``.
+
+    >>> build_filter_where_fragments({u'Status': [u'']})
+    ([u'("Status" IS NULL OR "Status" = \'\')'], [])
+    '''
+    null_clauses = []
+    regular_clauses = []
+    for col, values in filters.items():
+        if not isinstance(values, list):
+            values = [values]
+        empties = [v for v in values if v == u'']
+        reals = [v for v in values if v != u'']
+        safe_col = _quote_identifier(col)
+        if empties:
+            parts = [
+                u'{} IS NULL'.format(safe_col),
+                u"{} = ''".format(safe_col),
+            ]
+            if reals:
+                values_sql = u', '.join(_quote_literal(v) for v in reals)
+                parts.append(u'{} IN ({})'.format(safe_col, values_sql))
+            null_clauses.append(u'({})'.format(u' OR '.join(parts)))
+        elif reals:
+            if len(reals) == 1:
+                regular_clauses.append(
+                    u'{} = {}'.format(safe_col, _quote_literal(reals[0]))
+                )
+            else:
+                values_sql = u', '.join(_quote_literal(v) for v in reals)
+                regular_clauses.append(
+                    u'{} IN ({})'.format(safe_col, values_sql)
+                )
+    return null_clauses, regular_clauses
+
+
+def build_fts_where_fragment(colsearch_dict, plain_tsquery):
+    u'''
+    Build the SQL WHERE fragment that reproduces datastore_search's
+    full-text ``q`` behaviour so search keeps working under the SQL path.
+
+    Per-column searches (``colsearch_dict``) take precedence over the
+    global search (``plain_tsquery``), matching the existing ajax logic.
+    Returns a fragment string or ``None`` when there is no search.
+    '''
+    if colsearch_dict:
+        clauses = []
+        for col, tsquery in colsearch_dict.items():
+            clauses.append(
+                u"to_tsvector('simple', cast({} as text)) "
+                u"@@ to_tsquery('simple', {})".format(
+                    _quote_identifier(col), _quote_literal(tsquery)
+                )
+            )
+        return u' AND '.join(clauses) if clauses else None
+    if plain_tsquery:
+        return u"_full_text @@ to_tsquery('simple', {})".format(
+            _quote_literal(plain_tsquery)
+        )
+    return None
+
+
+def _build_order_by(sort_list):
+    u'''Build a quoted ORDER BY clause from a list of "col asc"/"col desc"
+    strings, handling column names containing spaces.'''
+    if not sort_list:
+        return u'"_id" asc'
+    quoted = []
+    for sort_item in sort_list:
+        parts = sort_item.rsplit(None, 1)
+        if len(parts) == 2:
+            col_name, direction = parts
+            quoted.append(
+                u'{} {}'.format(_quote_identifier(col_name), direction)
+            )
+        else:
+            quoted.append(_quote_identifier(sort_item))
+    return u', '.join(quoted)
+
+
+def _build_where_clause(null_clauses, regular_clauses, fts_fragment):
+    u'''Join the null/regular filter clauses and the FTS fragment into a
+    single SQL WHERE expression (no leading ``WHERE``).'''
+    where_clauses = list(null_clauses) + list(regular_clauses)
+    if fts_fragment:
+        where_clauses.append(fts_fragment)
+    return u' AND '.join(where_clauses) if where_clauses else u'1=1'
+
+
+def _build_select_fields(cols):
+    u'''Build the quoted SELECT field list, or ``*`` when no cols given.'''
+    if cols:
+        return u', '.join(_quote_identifier(c) for c in cols)
+    return u'*'
+
+
+def datastore_search_sql_null_filter(resource_id, null_clauses,
+                                     regular_clauses, fts_fragment,
+                                     sort_list, offset, limit, cols):
+    u'''
+    Run a datastore_search_sql query combining null filter clauses,
+    regular filter clauses and the full-text search fragment. Returns a
+    dict with the same shape as datastore_search ({records, total, fields})
+    so callers can render it unchanged.
+    '''
+    datastore_search_sql = get_action(u'datastore_search_sql')
+
+    where_clause = _build_where_clause(
+        null_clauses, regular_clauses, fts_fragment
+    )
+    select_fields = _build_select_fields(cols)
+    order_by = _build_order_by(sort_list)
+    safe_resource_id = _quote_identifier(resource_id)
+
+    sql = (
+        u'SELECT {select_fields} FROM {resource_id} WHERE {where_clause} '
+        u'ORDER BY {order_by} LIMIT {limit} OFFSET {offset}'
+    ).format(
+        select_fields=select_fields,
+        resource_id=safe_resource_id,
+        where_clause=where_clause,
+        order_by=order_by,
+        limit=int(limit),
+        offset=int(offset),
+    )
+
+    count_sql = (
+        u'SELECT COUNT(*) as total FROM {resource_id} WHERE {where_clause}'
+    ).format(
+        resource_id=safe_resource_id,
+        where_clause=where_clause,
+    )
+
+    response = datastore_search_sql(None, {u'sql': sql})
+    count_response = datastore_search_sql(None, {u'sql': count_sql})
+
+    records = response.get(u'records', [])
+    count_records = count_response.get(u'records', [])
+    total = int(count_records[0].get(u'total', 0)) if count_records else 0
+
+    return {
+        u'records': records,
+        u'total': total,
+        u'fields': [{u'id': c} for c in cols],
+    }
+
+
+def _iter_sql_null_filter_records(resource_id, null_clauses, regular_clauses,
+                                  fts_fragment, sort_list, cols,
+                                  paginate_by=EXPORT_PAGINATE_BY):
+    u'''
+    Yield records for a null-filter query page by page via
+    datastore_search_sql, so an export never loads the whole result set
+    into memory at once and is not silently capped at a fixed limit.
+    '''
+    datastore_search_sql = get_action(u'datastore_search_sql')
+
+    where_clause = _build_where_clause(
+        null_clauses, regular_clauses, fts_fragment
+    )
+    select_fields = _build_select_fields(cols)
+    order_by = _build_order_by(sort_list)
+    safe_resource_id = _quote_identifier(resource_id)
+
+    offset = 0
+    while True:
+        sql = (
+            u'SELECT {select_fields} FROM {resource_id} '
+            u'WHERE {where_clause} ORDER BY {order_by} '
+            u'LIMIT {limit} OFFSET {offset}'
+        ).format(
+            select_fields=select_fields,
+            resource_id=safe_resource_id,
+            where_clause=where_clause,
+            order_by=order_by,
+            limit=int(paginate_by),
+            offset=int(offset),
+        )
+        response = datastore_search_sql(None, {u'sql': sql})
+        records = response.get(u'records', [])
+        for record in records:
+            yield record
+        if len(records) < paginate_by:
+            break
+        offset += paginate_by
+
+
 def ajax(resource_view_id):
     resource_view = get_action(u'resource_view_show'
                                )(None, {
@@ -132,28 +351,55 @@ def ajax(resource_view_id):
             colsearch_dict[k] = format_fts_query(v)
         i += 1
 
-    if colsearch_dict:
-        search_text = json.dumps(colsearch_dict)
-    else:
-        search_text = format_fts_query(search_text) if search_text else u''
+    # A filter whose value is an empty string is the "null" option from the
+    # Add Filter dropdown. datastore_search filters can't match SQL NULLs, so
+    # those queries are routed through datastore_search_sql instead. When no
+    # null filters are present, keep using datastore_search unchanged.
+    null_clauses, regular_clauses = build_filter_where_fragments(filters)
+    dtdata = None
 
-    try:
-        response = datastore_search(
-            None, {
-                u"q": search_text,
-                u"resource_id": resource_view[u'resource_id'],
-                u'plain': False,
-                u'language': u'simple',
-                u"offset": offset,
-                u"limit": limit,
-                u"sort": u', '.join(sort_list),
-                u"filters": filters,
-            }
+    if null_clauses:
+        plain_tsquery = (
+            format_fts_query(search_text)
+            if (not colsearch_dict and search_text) else None
         )
-    except Exception:
-        query_error = u'Invalid search query... ' + search_text
-        dtdata = {u'error': query_error}
+        fts_fragment = build_fts_where_fragment(colsearch_dict, plain_tsquery)
+        try:
+            response = datastore_search_sql_null_filter(
+                resource_view[u'resource_id'],
+                null_clauses,
+                regular_clauses,
+                fts_fragment,
+                sort_list,
+                offset,
+                limit,
+                cols,
+            )
+        except Exception:
+            dtdata = {u'error': u'Invalid search query...'}
     else:
+        if colsearch_dict:
+            search_text = json.dumps(colsearch_dict)
+        else:
+            search_text = format_fts_query(search_text) if search_text else u''
+
+        try:
+            response = datastore_search(
+                None, {
+                    u"q": search_text,
+                    u"resource_id": resource_view[u'resource_id'],
+                    u'plain': False,
+                    u'language': u'simple',
+                    u"offset": offset,
+                    u"limit": limit,
+                    u"sort": u', '.join(sort_list),
+                    u"filters": filters,
+                }
+            )
+        except Exception:
+            dtdata = {u'error': u'Invalid search query... ' + search_text}
+
+    if dtdata is None:
         data = []
         null_label = h.og_datatablesview_null_label()
         for row in response[u'records']:
@@ -218,24 +464,124 @@ def filtered_download(resource_view_id):
                 k = column[u'name']
                 colsearch_dict[k] = format_fts_query(v)
 
-    if colsearch_dict:
-        search_text = json.dumps(colsearch_dict)
-    else:
-        search_text = format_fts_query(search_text) if search_text else ''
+    # When a null filter is present, datastore.dump can't express IS NULL, so
+    # build the export response here via datastore_search_sql. Otherwise keep
+    # the existing redirect to datastore.dump unchanged.
+    null_clauses, regular_clauses = build_filter_where_fragments(filters)
 
-    return h.redirect_to(
-        h.url_for(
-            u'datastore.dump',
-            resource_id=resource_view[u'resource_id']) + u'?' + urlencode(
-            {
-                u'q': search_text,
-                u'plain': False,
-                u'language': u'simple',
-                u'sort': u','.join(sort_list),
-                u'filters': json.dumps(filters),
-                u'format': request.form[u'format'],
-                u'fields': u','.join(cols),
-            }))
+    if not null_clauses:
+        if colsearch_dict:
+            search_text = json.dumps(colsearch_dict)
+        else:
+            search_text = format_fts_query(search_text) if search_text else ''
+
+        return h.redirect_to(
+            h.url_for(
+                u'datastore.dump',
+                resource_id=resource_view[u'resource_id']) + u'?' + urlencode(
+                {
+                    u'q': search_text,
+                    u'plain': False,
+                    u'language': u'simple',
+                    u'sort': u','.join(sort_list),
+                    u'filters': json.dumps(filters),
+                    u'format': request.form[u'format'],
+                    u'fields': u','.join(cols),
+                }))
+
+    plain_tsquery = (
+        format_fts_query(search_text)
+        if (not colsearch_dict and search_text) else None
+    )
+    fts_fragment = build_fts_where_fragment(colsearch_dict, plain_tsquery)
+
+    export_format = request.form.get(u'format', u'csv').lower()
+
+    # datastore.dump streams every row and supports csv/tsv/json/xml; mirror
+    # that here by streaming the null-filter result page by page instead of
+    # buffering the whole (potentially capped) result set in memory.
+    record_iter = _iter_sql_null_filter_records(
+        resource_view[u'resource_id'],
+        null_clauses,
+        regular_clauses,
+        fts_fragment,
+        sort_list,
+        cols,
+    )
+
+    # Pull the first page eagerly so a query failure (e.g. datastore SQL
+    # search disabled) surfaces as a clean error here, before any response
+    # body has been streamed, rather than silently exporting wrong data.
+    try:
+        first_record = next(record_iter)
+        records = chain([first_record], record_iter)
+    except StopIteration:
+        records = iter(())
+    except Exception:
+        return abort(400, u'Invalid search query...')
+
+    def stream_records():
+        return records
+
+    if export_format == u'xml':
+        def generate_xml():
+            with xml_writer([{u'id': c} for c in cols]) as writer:
+                for record in stream_records():
+                    yield writer.write_records(
+                        [{c: record.get(c) for c in cols}]
+                    )
+                yield writer.end_file()
+        return Response(
+            generate_xml(),
+            mimetype=u'text/xml; charset=utf-8',
+            headers={u'Content-Disposition':
+                     u'attachment; filename=export.xml'}
+        )
+
+    if export_format == u'json':
+        def generate_json():
+            yield u'[\n'
+            first = True
+            for record in stream_records():
+                row = {c: record.get(c) for c in cols}
+                yield (u'' if first else u',\n') + json.dumps(row)
+                first = False
+            yield u'\n]'
+        return Response(
+            generate_json(),
+            mimetype=u'application/json; charset=utf-8',
+            headers={u'Content-Disposition':
+                     u'attachment; filename=export.json'}
+        )
+
+    delimiter = u'\t' if export_format == u'tsv' else u','
+    mimetype = (u'text/tab-separated-values; charset=utf-8'
+                if export_format == u'tsv' else u'text/csv; charset=utf-8')
+    filename = u'export.tsv' if export_format == u'tsv' else u'export.csv'
+
+    def generate_delimited():
+        buf = io.StringIO()
+        writer = csv.DictWriter(
+            buf, fieldnames=cols, delimiter=delimiter, extrasaction=u'ignore'
+        )
+        # Always emit the header row, even for an empty result set, so the
+        # download matches datastore.dump rather than being a 0-byte file.
+        writer.writeheader()
+        yield buf.getvalue()
+        buf.seek(0)
+        buf.truncate(0)
+        for record in stream_records():
+            writer.writerow(record)
+            yield buf.getvalue()
+            buf.seek(0)
+            buf.truncate(0)
+
+    return Response(
+        generate_delimited(),
+        mimetype=mimetype,
+        headers={u'Content-Disposition':
+                 u'attachment; filename={}'.format(filename)}
+    )
 
 
 ogdatatablesview.add_url_rule(

--- a/ckanext/og_datatablesview/blueprint.py
+++ b/ckanext/og_datatablesview/blueprint.py
@@ -9,16 +9,30 @@ import io
 from flask import Blueprint, Response
 
 
-from ckan.common import json
+from ckan.common import json, config
 from ckan.plugins.toolkit import get_action, request, h, abort
 from ckanext.datastore.writer import xml_writer
 import re
 
 ogdatatablesview = Blueprint(u'ogdatatablesview', __name__)
 
-# Page size used when streaming a null-filter export, matching CKAN's
-# datastore dump (ckanext.datastore.blueprint.PAGINATE_BY).
+# Default page size when streaming a null-filter export, matching CKAN's
+# datastore dump (ckanext.datastore.blueprint.PAGINATE_BY). The effective
+# page size is clamped to ckan.datastore.search.rows_max at call time, since
+# datastore_search_sql wraps every query in LIMIT rows_max + 1.
 EXPORT_PAGINATE_BY = 32000
+
+
+def _export_paginate_by():
+    u'''Return the page size to use when streaming a null-filter export.
+
+    datastore_search_sql caps every query at ``rows_max + 1`` rows
+    (ckanext.datastore.backend.postgres). Paging in chunks larger than
+    rows_max would make the first short page look like the end of the
+    result set, silently truncating the export, so never page above it.
+    '''
+    rows_max = int(config.get(u'ckan.datastore.search.rows_max', 32000))
+    return min(EXPORT_PAGINATE_BY, rows_max)
 
 
 def format_fts_query(search_value):
@@ -203,6 +217,30 @@ def _build_select_fields(cols):
     return u'*'
 
 
+def _build_null_filter_select_sql(resource_id, null_clauses, regular_clauses,
+                                  fts_fragment, sort_list, cols, limit,
+                                  offset):
+    u'''
+    Build the paginated SELECT statement shared by the table-view and export
+    null-filter paths, so the WHERE/SELECT/ORDER BY construction lives in one
+    place and future changes (e.g. adding a schema prefix) are a single edit.
+    '''
+    where_clause = _build_where_clause(
+        null_clauses, regular_clauses, fts_fragment
+    )
+    return (
+        u'SELECT {select_fields} FROM {resource_id} WHERE {where_clause} '
+        u'ORDER BY {order_by} LIMIT {limit} OFFSET {offset}'
+    ).format(
+        select_fields=_build_select_fields(cols),
+        resource_id=_quote_identifier(resource_id),
+        where_clause=where_clause,
+        order_by=_build_order_by(sort_list),
+        limit=int(limit),
+        offset=int(offset),
+    )
+
+
 def datastore_search_sql_null_filter(resource_id, null_clauses,
                                      regular_clauses, fts_fragment,
                                      sort_list, offset, limit, cols):
@@ -214,32 +252,25 @@ def datastore_search_sql_null_filter(resource_id, null_clauses,
     '''
     datastore_search_sql = get_action(u'datastore_search_sql')
 
+    sql = _build_null_filter_select_sql(
+        resource_id, null_clauses, regular_clauses, fts_fragment,
+        sort_list, cols, limit, offset,
+    )
+
     where_clause = _build_where_clause(
         null_clauses, regular_clauses, fts_fragment
     )
-    select_fields = _build_select_fields(cols)
-    order_by = _build_order_by(sort_list)
-    safe_resource_id = _quote_identifier(resource_id)
-
-    sql = (
-        u'SELECT {select_fields} FROM {resource_id} WHERE {where_clause} '
-        u'ORDER BY {order_by} LIMIT {limit} OFFSET {offset}'
-    ).format(
-        select_fields=select_fields,
-        resource_id=safe_resource_id,
-        where_clause=where_clause,
-        order_by=order_by,
-        limit=int(limit),
-        offset=int(offset),
-    )
-
     count_sql = (
         u'SELECT COUNT(*) as total FROM {resource_id} WHERE {where_clause}'
     ).format(
-        resource_id=safe_resource_id,
+        resource_id=_quote_identifier(resource_id),
         where_clause=where_clause,
     )
 
+    # DataTables needs the filtered total for its pager, so a separate
+    # COUNT(*) runs alongside the page query. This means each page pays a
+    # count scan; acceptable here since the null-filter path is the
+    # exception rather than the common case.
     response = datastore_search_sql(None, {u'sql': sql})
     count_response = datastore_search_sql(None, {u'sql': count_sql})
 
@@ -256,34 +287,21 @@ def datastore_search_sql_null_filter(resource_id, null_clauses,
 
 def _iter_sql_null_filter_records(resource_id, null_clauses, regular_clauses,
                                   fts_fragment, sort_list, cols,
-                                  paginate_by=EXPORT_PAGINATE_BY):
+                                  paginate_by=None):
     u'''
     Yield records for a null-filter query page by page via
     datastore_search_sql, so an export never loads the whole result set
     into memory at once and is not silently capped at a fixed limit.
     '''
+    if paginate_by is None:
+        paginate_by = _export_paginate_by()
     datastore_search_sql = get_action(u'datastore_search_sql')
-
-    where_clause = _build_where_clause(
-        null_clauses, regular_clauses, fts_fragment
-    )
-    select_fields = _build_select_fields(cols)
-    order_by = _build_order_by(sort_list)
-    safe_resource_id = _quote_identifier(resource_id)
 
     offset = 0
     while True:
-        sql = (
-            u'SELECT {select_fields} FROM {resource_id} '
-            u'WHERE {where_clause} ORDER BY {order_by} '
-            u'LIMIT {limit} OFFSET {offset}'
-        ).format(
-            select_fields=select_fields,
-            resource_id=safe_resource_id,
-            where_clause=where_clause,
-            order_by=order_by,
-            limit=int(paginate_by),
-            offset=int(offset),
+        sql = _build_null_filter_select_sql(
+            resource_id, null_clauses, regular_clauses, fts_fragment,
+            sort_list, cols, paginate_by, offset,
         )
         response = datastore_search_sql(None, {u'sql': sql})
         records = response.get(u'records', [])
@@ -520,13 +538,15 @@ def filtered_download(resource_view_id):
     except Exception:
         return abort(400, u'Invalid search query...')
 
-    def stream_records():
-        return records
-
     if export_format == u'xml':
         def generate_xml():
             with xml_writer([{u'id': c} for c in cols]) as writer:
-                for record in stream_records():
+                # Flush the opening <data> tag up front. xml_writer only
+                # emits it on the first write_records() call, so an empty
+                # result set would otherwise yield just </data> and produce
+                # malformed XML.
+                yield writer.write_records([])
+                for record in records:
                     yield writer.write_records(
                         [{c: record.get(c) for c in cols}]
                     )
@@ -542,7 +562,7 @@ def filtered_download(resource_view_id):
         def generate_json():
             yield u'[\n'
             first = True
-            for record in stream_records():
+            for record in records:
                 row = {c: record.get(c) for c in cols}
                 yield (u'' if first else u',\n') + json.dumps(row)
                 first = False
@@ -570,7 +590,7 @@ def filtered_download(resource_view_id):
         yield buf.getvalue()
         buf.seek(0)
         buf.truncate(0)
-        for record in stream_records():
+        for record in records:
             writer.writerow(record)
             yield buf.getvalue()
             buf.seek(0)

--- a/ckanext/og_datatablesview/tests/test_logic.py
+++ b/ckanext/og_datatablesview/tests/test_logic.py
@@ -2,7 +2,16 @@ import pytest
 
 import ckan.plugins.toolkit as toolkit
 from ckan.tests import factories
-from ckanext.og_datatablesview.blueprint import format_fts_query
+from ckanext.og_datatablesview.blueprint import (
+    format_fts_query,
+    build_filter_where_fragments,
+    build_fts_where_fragment,
+    _quote_identifier,
+    _quote_literal,
+    _build_where_clause,
+    _build_select_fields,
+    _build_order_by,
+)
 
 
 @pytest.mark.usefixtures("clean_db")
@@ -446,3 +455,179 @@ class TestFormatFtsQuery:
         # Date with compound word in same search
         result = format_fts_query('Board/Village 1/13/2025')
         assert result == '(Board:* | Village:*) & 1/13/2025:*'
+
+
+class TestBuildFilterWhereFragments:
+
+    def test_no_filters(self):
+        null_clauses, regular_clauses = build_filter_where_fragments({})
+        assert null_clauses == []
+        assert regular_clauses == []
+
+    def test_null_only(self):
+        null_clauses, regular_clauses = build_filter_where_fragments(
+            {'Status': ['']}
+        )
+        assert null_clauses == [
+            '("Status" IS NULL OR "Status" = \'\')'
+        ]
+        assert regular_clauses == []
+
+    def test_null_with_real_values(self):
+        # Empty string plus real values for the same column
+        null_clauses, regular_clauses = build_filter_where_fragments(
+            {'Status': ['', 'Open', 'Closed']}
+        )
+        assert null_clauses == [
+            '("Status" IS NULL OR "Status" = \'\' '
+            'OR "Status" IN (\'Open\', \'Closed\'))'
+        ]
+        assert regular_clauses == []
+
+    def test_single_regular_filter(self):
+        null_clauses, regular_clauses = build_filter_where_fragments(
+            {'Department': ['BTDT']}
+        )
+        assert null_clauses == []
+        assert regular_clauses == ['"Department" = \'BTDT\'']
+
+    def test_multiple_regular_filter_values_use_in(self):
+        null_clauses, regular_clauses = build_filter_where_fragments(
+            {'Department': ['BTDT', 'INFO']}
+        )
+        assert null_clauses == []
+        assert regular_clauses == [
+            '"Department" IN (\'BTDT\', \'INFO\')'
+        ]
+
+    def test_mixed_null_and_regular_filters(self):
+        null_clauses, regular_clauses = build_filter_where_fragments(
+            {'Status': [''], 'Department': ['BTDT']}
+        )
+        assert null_clauses == [
+            '("Status" IS NULL OR "Status" = \'\')'
+        ]
+        assert regular_clauses == ['"Department" = \'BTDT\'']
+
+    def test_scalar_value_normalised(self):
+        null_clauses, regular_clauses = build_filter_where_fragments(
+            {'Department': 'BTDT'}
+        )
+        assert regular_clauses == ['"Department" = \'BTDT\'']
+
+    def test_identifier_escaping(self):
+        # Double quotes in column name must be doubled
+        null_clauses, _ = build_filter_where_fragments({'a"b': ['']})
+        assert null_clauses == ['("a""b" IS NULL OR "a""b" = \'\')']
+
+    def test_literal_escaping(self):
+        # Single quotes in value must be doubled
+        _, regular_clauses = build_filter_where_fragments(
+            {'Name': ["O'Brien"]}
+        )
+        assert regular_clauses == ['"Name" = \'O\'\'Brien\'']
+
+    def test_column_name_with_spaces(self):
+        null_clauses, _ = build_filter_where_fragments(
+            {'MPN Approval Status': ['']}
+        )
+        assert null_clauses == [
+            '("MPN Approval Status" IS NULL '
+            'OR "MPN Approval Status" = \'\')'
+        ]
+
+
+class TestBuildFtsWhereFragment:
+
+    def test_no_search(self):
+        assert build_fts_where_fragment({}, None) is None
+        assert build_fts_where_fragment({}, '') is None
+
+    def test_plain_query(self):
+        result = build_fts_where_fragment({}, 'boston:*')
+        assert result == "_full_text @@ to_tsquery('simple', 'boston:*')"
+
+    def test_per_column_query(self):
+        result = build_fts_where_fragment({'name': 'boston:*'}, None)
+        assert result == (
+            "to_tsvector('simple', cast(\"name\" as text)) "
+            "@@ to_tsquery('simple', 'boston:*')"
+        )
+
+    def test_colsearch_takes_precedence_over_plain(self):
+        result = build_fts_where_fragment({'name': 'boston:*'}, 'ignored:*')
+        assert 'to_tsvector' in result
+        assert 'ignored' not in result
+
+    def test_per_column_multiple_columns(self):
+        result = build_fts_where_fragment(
+            {'name': 'a:*', 'city': 'b:*'}, None
+        )
+        assert (
+            "to_tsvector('simple', cast(\"name\" as text)) "
+            "@@ to_tsquery('simple', 'a:*')"
+        ) in result
+        assert (
+            "to_tsvector('simple', cast(\"city\" as text)) "
+            "@@ to_tsquery('simple', 'b:*')"
+        ) in result
+        assert ' AND ' in result
+
+    def test_literal_escaping(self):
+        result = build_fts_where_fragment({}, "o'brien:*")
+        assert result == "_full_text @@ to_tsquery('simple', 'o''brien:*')"
+
+
+class TestQuoting:
+
+    def test_identifier_doubles_quotes(self):
+        assert _quote_identifier('a"b') == '"a""b"'
+
+    def test_identifier_strips_nul(self):
+        # NUL bytes must be stripped, matching CKAN's postgres.identifier
+        assert _quote_identifier('a\x00b') == '"ab"'
+
+    def test_literal_doubles_single_quotes(self):
+        assert _quote_literal("O'Brien") == "'O''Brien'"
+
+    def test_literal_strips_nul(self):
+        # NUL bytes must be stripped, matching CKAN's postgres.literal_string
+        assert _quote_literal('a\x00b') == "'ab'"
+
+
+class TestBuildWhereClause:
+
+    def test_no_clauses_returns_true(self):
+        assert _build_where_clause([], [], None) == '1=1'
+
+    def test_combines_all_clauses_with_and(self):
+        result = _build_where_clause(
+            ['(x IS NULL)'], ['"d" = \'a\''], 'fts_frag'
+        )
+        assert result == "(x IS NULL) AND \"d\" = 'a' AND fts_frag"
+
+    def test_skips_empty_fts_fragment(self):
+        result = _build_where_clause(['(x IS NULL)'], [], None)
+        assert result == '(x IS NULL)'
+
+
+class TestBuildSelectFields:
+
+    def test_quotes_each_column(self):
+        assert _build_select_fields(['a', 'b c']) == '"a", "b c"'
+
+    def test_empty_cols_returns_star(self):
+        assert _build_select_fields([]) == '*'
+
+
+class TestBuildOrderBy:
+
+    def test_no_sort_defaults_to_id(self):
+        assert _build_order_by([]) == '"_id" asc'
+
+    def test_column_with_spaces(self):
+        assert _build_order_by(['MPN Approval Status asc']) == \
+            '"MPN Approval Status" asc'
+
+    def test_multiple_sorts(self):
+        assert _build_order_by(['a asc', 'b desc']) == '"a" asc, "b" desc'


### PR DESCRIPTION
# Description
The "Add Filter" dropdown exposes a null option (encoded as an empty value), but CKAN's datastore_search filters can't match SQL NULL. This routes any query containing a null filter through datastore_search_sql so it correctly matches both NULL and empty-string cells, while leaving the existing datastore_search / datastore.dump paths untouched when no null filter is present.

## Changes
- ajax — when a null filter is detected, build a SQL WHERE clause (IS NULL OR = '') via datastore_search_sql, preserving FTS search, per-column search, regular IN filters, sorting, and pagination. The response keeps the same shape so rendering is unchanged.
- filtered_download — null-filter exports can't be expressed by datastore.dump, so they're streamed directly here via datastore_search_sql, paged (32k rows) to avoid buffering or capping the result set. Supports csv/tsv/json/xml, matching datastore.dump output (including a header row on empty results). The first page is pulled eagerly so query errors surface cleanly before streaming begins.
- SQL safety — identifiers and literals are quoted/escaped (doubled quotes, stripped NUL bytes) mirroring CKAN's postgres.identifier / literal_string helpers.

## Tests
Added unit coverage for filter-fragment building, FTS fragment building, identifier/literal quoting, and WHERE/SELECT/ORDER BY construction (including column names with spaces and special characters).

## Notes
The null-filter export path requires datastore_search_sql to be enabled.