### PR TITLE
Add per-column display prefix/suffix for numeric columns

### DIFF
--- a/ckanext/og_datatables_datefilterview/assets/og_datatables_datefilterview.js
+++ b/ckanext/og_datatables_datefilterview/assets/og_datatables_datefilterview.js
@@ -411,6 +411,30 @@ this.ckan.module('og_datatables_datefilter_view', function (jQuery) {
               }
             }
         }
+
+        // apply the per-column display prefix/suffix, if any are configured.
+        // this wraps whatever render the column already has (numeric has none,
+        // dates/html do) and only touches the 'display' value, so ordering,
+        // searching and the underlying data stay untouched.
+        const rawPrefix = (typeof gcolumnPrefixes !== 'undefined' &&
+          gcolumnPrefixes[colDefn.id]) || ''
+        const rawSuffix = (typeof gcolumnSuffixes !== 'undefined' &&
+          gcolumnSuffixes[colDefn.id]) || ''
+        if (rawPrefix || rawSuffix) {
+          const prefix = esc(rawPrefix)
+          const suffix = esc(rawSuffix)
+          const baseRender = colDict.render
+          colDict.render = function (data, type, row, meta) {
+            const rendered = baseRender ? baseRender(data, type, row, meta) : data
+            if (type !== 'display') {
+              return rendered
+            }
+            if (rendered === null || rendered === undefined || rendered === '') {
+              return rendered
+            }
+            return prefix + rendered + suffix
+          }
+        }
         dynamicCols.push(colDict)
       })
 

--- a/ckanext/og_datatables_datefilterview/assets/og_datatables_datefilterview_form.js
+++ b/ckanext/og_datatables_datefilterview/assets/og_datatables_datefilterview_form.js
@@ -9,5 +9,29 @@ window.addEventListener('load', function(){
     $(dtHideAll).on('click', function(_event){
       $(dtColSelects).prop('checked', false).change().blur();
     });
+
+    // Serialize the per-column prefix/suffix inputs into the single hidden
+    // column_prefixes / column_suffixes fields on submit. The column ids are
+    // dynamic, so we can't POST one field per column; instead we send a JSON
+    // map keyed by column id, which the matching validator decodes.
+    function serializeAffixes(inputClass, hiddenSelector){
+      let hiddenField = $(hiddenSelector);
+      if (!hiddenField.length) {
+        return;
+      }
+      hiddenField.closest('form').on('submit', function(){
+        let affixes = {};
+        $(inputClass).each(function(){
+          let colid = $(this).data('colid');
+          let val = $(this).val();
+          if (colid !== undefined && val !== '') {
+            affixes[colid] = val;
+          }
+        });
+        hiddenField.val(JSON.stringify(affixes));
+      });
+    }
+    serializeAffixes('.dt-col-prefix', '#field-column_prefixes');
+    serializeAffixes('.dt-col-suffix', '#field-column_suffixes');
   });
 });

--- a/ckanext/og_datatables_datefilterview/helpers.py
+++ b/ckanext/og_datatables_datefilterview/helpers.py
@@ -1,8 +1,76 @@
 # encoding: utf-8
+import json
+
 import ckan.plugins.toolkit as toolkit
 from typing import (
     Any, Optional
 )
+
+
+# Datastore/postgres numeric type names the prefix option applies to. The data
+# dictionary reports postgres type names (e.g. numeric, int4, float8), so we
+# match against those as well as the friendlier aliases.
+NUMERIC_COLUMN_TYPES = frozenset({
+    'numeric', 'number', 'decimal', 'money',
+    'int', 'integer', 'smallint', 'bigint',
+    'int2', 'int4', 'int8',
+    'float', 'float4', 'float8', 'real', 'double precision',
+})
+
+
+def og_datatablesview_is_numeric_column(field_type: Any) -> bool:
+    """
+    Return True if the given data dictionary column type is a numeric type.
+
+    Used by the config form to only offer the display-prefix option on numeric
+    columns.
+    """
+    return str(field_type or '').lower() in NUMERIC_COLUMN_TYPES
+
+
+def _og_datatablesview_column_affixes(value: Any) -> dict[str, str]:
+    """
+    Normalise a per-column affix map (prefixes or suffixes) into a
+    ``{column_id: affix}`` dict.
+
+    The value can arrive as a dict (the validated config, e.g. on the initial
+    edit form or in the view) or as a JSON string (the raw value POSTed by the
+    config form when it is re-rendered after a validation error). Blank affixes
+    are dropped so we only keep columns that actually have one.
+    """
+    if not value:
+        return {}
+
+    if isinstance(value, str):
+        try:
+            value = json.loads(value)
+        except ValueError:
+            return {}
+
+    if not isinstance(value, dict):
+        return {}
+
+    return {
+        str(k): str(v)
+        for k, v in value.items()
+        if v is not None and str(v) != ''
+    }
+
+
+def og_datatablesview_column_prefixes(value: Any) -> dict[str, str]:
+    """
+    Normalise the per-column display prefixes into a ``{column_id: prefix}``
+    dict. See :func:`_og_datatablesview_column_affixes`.
+    """
+    return _og_datatablesview_column_affixes(value)
+
+
+def og_datatablesview_column_suffixes(value: Any) -> dict[str, str]:
+    """
+    Normalise the per-column display suffixes into a ``{column_id: suffix}``
+    dict. See :func:`_og_datatablesview_column_affixes`.
+    """
+    return _og_datatablesview_column_affixes(value)
 
 
 def og_datatables_datefilterview_null_label() -> str:

--- a/ckanext/og_datatables_datefilterview/plugin.py
+++ b/ckanext/og_datatables_datefilterview/plugin.py
@@ -152,6 +152,8 @@ class OG_DataTablesDateFilterView(p.SingletonPlugin):
                 u'show_fields': [ignore_missing],
                 u'sort_column': [ignore_missing],
                 u'sort_order': [ignore_missing],
+                u'column_prefixes': [ignore_missing, og_datatables_column_prefixes],
+                u'column_suffixes': [ignore_missing, og_datatables_column_suffixes],
                 u'filterable': [default(True), boolean_validator],
             }
         }
@@ -161,6 +163,8 @@ class OG_DataTablesDateFilterView(p.SingletonPlugin):
     def get_validators(self):
         return {
             'configurabledefaults_validator': configurabledefaults_validator,
+            'og_datatables_column_prefixes': og_datatables_column_prefixes,
+            'og_datatables_column_suffixes': og_datatables_column_suffixes,
         }
 
     # ITemplateHelpers
@@ -169,7 +173,32 @@ class OG_DataTablesDateFilterView(p.SingletonPlugin):
         return {
             'og_datatables_datefilterview_null_label': helpers.og_datatables_datefilterview_null_label,
             'og_datastore_dictionary': helpers.og_datastore_dictionary,
+            'og_datatablesview_column_prefixes': helpers.og_datatablesview_column_prefixes,
+            'og_datatablesview_column_suffixes': helpers.og_datatablesview_column_suffixes,
+            'og_datatablesview_is_numeric_column': helpers.og_datatablesview_is_numeric_column,
         }
+
+
+def og_datatables_column_prefixes(value):
+    u'''
+    Validator for the per-column display prefixes. The value arrives as a JSON
+    string when POSTed from the config form, or as a dict when set via the
+    API/tests. Delegates to the shared helper so the form template and the
+    stored config always use the same normalisation.
+    '''
+    if value is missing:
+        return {}
+    return helpers.og_datatablesview_column_prefixes(value)
+
+
+def og_datatables_column_suffixes(value):
+    u'''
+    Validator for the per-column display suffixes. Mirrors
+    :func:`og_datatables_column_prefixes`.
+    '''
+    if value is missing:
+        return {}
+    return helpers.og_datatablesview_column_suffixes(value)
 
 
 def configurabledefaults_validator(default_configurable_value):

--- a/ckanext/og_datatables_datefilterview/templates/og_datatables_datefilterview/datatables_form.html
+++ b/ckanext/og_datatables_datefilterview/templates/og_datatables_datefilterview/datatables_form.html
@@ -71,12 +71,16 @@
     <button class="dt-show-all btn btn-default btn-sm" type="button" aria-label="Show all fields"><span class="me-3"><i class="fa fa-eye"></i>&nbsp;{{ _('Show All') }}</span></button>
     <button class="dt-hide-all btn btn-default btn-sm" type="button" aria-label="Hide all fields"><span><i class="fa fa-eye-slash"></i>&nbsp;{{ _('Hide All') }}</span></button>
   </div>
+  {% set column_prefixes = h.og_datatablesview_column_prefixes(data.get('column_prefixes')) %}
+  {% set column_suffixes = h.og_datatablesview_column_suffixes(data.get('column_suffixes')) %}
   <div class="controls dt-select-columns mt-3">
     <table class="table table-striped table-bordered">
       <thead>
         <tr>
           <th scope="col">{{ _('Column') }}</th>
           <th scope="col">{{ _('Label') }}</th>
+          <th scope="col">{{ _('Prefix') }}</th>
+          <th scope="col">{{ _('Suffix') }}</th>
         </tr>
       </thead>
         <tr>
@@ -90,6 +94,8 @@
             'checked' if '_id' in data.show_fields else '' }}
             />_id</label>
           </td>
+          <td></td>
+          <td></td>
           <td></td>
         </tr>
       {% for f in h.datastore_dictionary(resource.id) %}
@@ -108,10 +114,32 @@
               {{ f.get('info', {}).label }}
             {%- endblock -%}
           </td>
+          <td>
+            {%- if h.og_datatablesview_is_numeric_column(f.type) -%}
+            <input type="text" class="form-control dt-col-prefix"
+              data-colid="{{ f.id }}"
+              value="{{ column_prefixes.get(f.id, '') }}"
+              placeholder="{{ _('E.g. $') }}"
+              aria-label="{{ _('Prefix for') }} {{ f.id }}"
+              title="{{ _('Text to prepend to each value in this column (display only)') }}" />
+            {%- endif -%}
+          </td>
+          <td>
+            {%- if h.og_datatablesview_is_numeric_column(f.type) -%}
+            <input type="text" class="form-control dt-col-suffix"
+              data-colid="{{ f.id }}"
+              value="{{ column_suffixes.get(f.id, '') }}"
+              placeholder="{{ _('E.g. dollars') }}"
+              aria-label="{{ _('Suffix for') }} {{ f.id }}"
+              title="{{ _('Text to append to each value in this column (display only)') }}" />
+            {%- endif -%}
+          </td>
         </tr>
       {% endfor %}
     </table>
   </div>
+  <input type="hidden" name="column_prefixes" id="field-column_prefixes" />
+  <input type="hidden" name="column_suffixes" id="field-column_suffixes" />
 </div>
 
 <div class="form-group control-select">

--- a/ckanext/og_datatables_datefilterview/templates/og_datatables_datefilterview/datatables_view.html
+++ b/ckanext/og_datatables_datefilterview/templates/og_datatables_datefilterview/datatables_view.html
@@ -16,6 +16,8 @@
 <script type=text/javascript>
     const gdataDict = {{ datadictionary|tojson }}
     const gresviewId = '{{ resource_view.id }}'
+    const gcolumnPrefixes = {{ resource_view.get('column_prefixes', {})|tojson }}
+    const gcolumnSuffixes = {{ resource_view.get('column_suffixes', {})|tojson }}
 </script>
 
 <div id="resize_wrapper">

--- a/ckanext/og_datatablesview/assets/og_datatablesview.js
+++ b/ckanext/og_datatablesview/assets/og_datatablesview.js
@@ -411,6 +411,30 @@ this.ckan.module('og_datatables_view', function (jQuery) {
               }
             }
         }
+
+        // apply the per-column display prefix/suffix, if any are configured.
+        // this wraps whatever render the column already has (numeric has none,
+        // dates/html do) and only touches the 'display' value, so ordering,
+        // searching and the underlying data stay untouched.
+        const rawPrefix = (typeof gcolumnPrefixes !== 'undefined' &&
+          gcolumnPrefixes[colDefn.id]) || ''
+        const rawSuffix = (typeof gcolumnSuffixes !== 'undefined' &&
+          gcolumnSuffixes[colDefn.id]) || ''
+        if (rawPrefix || rawSuffix) {
+          const prefix = esc(rawPrefix)
+          const suffix = esc(rawSuffix)
+          const baseRender = colDict.render
+          colDict.render = function (data, type, row, meta) {
+            const rendered = baseRender ? baseRender(data, type, row, meta) : data
+            if (type !== 'display') {
+              return rendered
+            }
+            if (rendered === null || rendered === undefined || rendered === '') {
+              return rendered
+            }
+            return prefix + rendered + suffix
+          }
+        }
         dynamicCols.push(colDict)
       })
 

--- a/ckanext/og_datatablesview/assets/og_datatablesview_form.js
+++ b/ckanext/og_datatablesview/assets/og_datatablesview_form.js
@@ -9,5 +9,29 @@ window.addEventListener('load', function(){
     $(dtHideAll).on('click', function(_event){
       $(dtColSelects).prop('checked', false).change().blur();
     });
+
+    // Serialize the per-column prefix/suffix inputs into the single hidden
+    // column_prefixes / column_suffixes fields on submit. The column ids are
+    // dynamic, so we can't POST one field per column; instead we send a JSON
+    // map keyed by column id, which the matching validator decodes.
+    function serializeAffixes(inputClass, hiddenSelector){
+      let hiddenField = $(hiddenSelector);
+      if (!hiddenField.length) {
+        return;
+      }
+      hiddenField.closest('form').on('submit', function(){
+        let affixes = {};
+        $(inputClass).each(function(){
+          let colid = $(this).data('colid');
+          let val = $(this).val();
+          if (colid !== undefined && val !== '') {
+            affixes[colid] = val;
+          }
+        });
+        hiddenField.val(JSON.stringify(affixes));
+      });
+    }
+    serializeAffixes('.dt-col-prefix', '#field-column_prefixes');
+    serializeAffixes('.dt-col-suffix', '#field-column_suffixes');
   });
 });

--- a/ckanext/og_datatablesview/helpers.py
+++ b/ckanext/og_datatablesview/helpers.py
@@ -1,8 +1,76 @@
 # encoding: utf-8
+import json
+
 import ckan.plugins.toolkit as toolkit
 from typing import (
     Any, Optional
 )
+
+
+# Datastore/postgres numeric type names the prefix option applies to. The data
+# dictionary reports postgres type names (e.g. numeric, int4, float8), so we
+# match against those as well as the friendlier aliases.
+NUMERIC_COLUMN_TYPES = frozenset({
+    'numeric', 'number', 'decimal', 'money',
+    'int', 'integer', 'smallint', 'bigint',
+    'int2', 'int4', 'int8',
+    'float', 'float4', 'float8', 'real', 'double precision',
+})
+
+
+def og_datatablesview_is_numeric_column(field_type: Any) -> bool:
+    """
+    Return True if the given data dictionary column type is a numeric type.
+
+    Used by the config form to only offer the display-prefix option on numeric
+    columns.
+    """
+    return str(field_type or '').lower() in NUMERIC_COLUMN_TYPES
+
+
+def _og_datatablesview_column_affixes(value: Any) -> dict[str, str]:
+    """
+    Normalise a per-column affix map (prefixes or suffixes) into a
+    ``{column_id: affix}`` dict.
+
+    The value can arrive as a dict (the validated config, e.g. on the initial
+    edit form or in the view) or as a JSON string (the raw value POSTed by the
+    config form when it is re-rendered after a validation error). Blank affixes
+    are dropped so we only keep columns that actually have one.
+    """
+    if not value:
+        return {}
+
+    if isinstance(value, str):
+        try:
+            value = json.loads(value)
+        except ValueError:
+            return {}
+
+    if not isinstance(value, dict):
+        return {}
+
+    return {
+        str(k): str(v)
+        for k, v in value.items()
+        if v is not None and str(v) != ''
+    }
+
+
+def og_datatablesview_column_prefixes(value: Any) -> dict[str, str]:
+    """
+    Normalise the per-column display prefixes into a ``{column_id: prefix}``
+    dict. See :func:`_og_datatablesview_column_affixes`.
+    """
+    return _og_datatablesview_column_affixes(value)
+
+
+def og_datatablesview_column_suffixes(value: Any) -> dict[str, str]:
+    """
+    Normalise the per-column display suffixes into a ``{column_id: suffix}``
+    dict. See :func:`_og_datatablesview_column_affixes`.
+    """
+    return _og_datatablesview_column_affixes(value)
 
 
 def og_datatablesview_null_label() -> str:

--- a/ckanext/og_datatablesview/plugin.py
+++ b/ckanext/og_datatablesview/plugin.py
@@ -152,6 +152,8 @@ class OG_DataTablesView(p.SingletonPlugin):
                 u'show_fields': [ignore_missing],
                 u'sort_column': [ignore_missing],
                 u'sort_order': [ignore_missing],
+                u'column_prefixes': [ignore_missing, og_datatables_column_prefixes],
+                u'column_suffixes': [ignore_missing, og_datatables_column_suffixes],
                 u'filterable': [default(True), boolean_validator],
             }
         }
@@ -161,6 +163,8 @@ class OG_DataTablesView(p.SingletonPlugin):
     def get_validators(self):
         return {
             'configurabledefaults_validator': configurabledefaults_validator,
+            'og_datatables_column_prefixes': og_datatables_column_prefixes,
+            'og_datatables_column_suffixes': og_datatables_column_suffixes,
         }
 
     # ITemplateHelpers
@@ -169,7 +173,32 @@ class OG_DataTablesView(p.SingletonPlugin):
         return {
             'og_datatablesview_null_label': helpers.og_datatablesview_null_label,
             'og_datastore_dictionary': helpers.og_datastore_dictionary,
+            'og_datatablesview_column_prefixes': helpers.og_datatablesview_column_prefixes,
+            'og_datatablesview_column_suffixes': helpers.og_datatablesview_column_suffixes,
+            'og_datatablesview_is_numeric_column': helpers.og_datatablesview_is_numeric_column,
         }
+
+
+def og_datatables_column_prefixes(value):
+    u'''
+    Validator for the per-column display prefixes. The value arrives as a JSON
+    string when POSTed from the config form, or as a dict when set via the
+    API/tests. Delegates to the shared helper so the form template and the
+    stored config always use the same normalisation.
+    '''
+    if value is missing:
+        return {}
+    return helpers.og_datatablesview_column_prefixes(value)
+
+
+def og_datatables_column_suffixes(value):
+    u'''
+    Validator for the per-column display suffixes. Mirrors
+    :func:`og_datatables_column_prefixes`.
+    '''
+    if value is missing:
+        return {}
+    return helpers.og_datatablesview_column_suffixes(value)
 
 
 def configurabledefaults_validator(default_configurable_value):

--- a/ckanext/og_datatablesview/templates/og_datatables/datatables_form.html
+++ b/ckanext/og_datatablesview/templates/og_datatables/datatables_form.html
@@ -71,12 +71,16 @@
     <button class="dt-show-all btn btn-default btn-sm" type="button" aria-label="Show all fields"><span class="me-3"><i class="fa fa-eye"></i>&nbsp;{{ _('Show All') }}</span></button>
     <button class="dt-hide-all btn btn-default btn-sm" type="button" aria-label="Hide all fields"><span><i class="fa fa-eye-slash"></i>&nbsp;{{ _('Hide All') }}</span></button>
   </div>
+  {% set column_prefixes = h.og_datatablesview_column_prefixes(data.get('column_prefixes')) %}
+  {% set column_suffixes = h.og_datatablesview_column_suffixes(data.get('column_suffixes')) %}
   <div class="controls dt-select-columns mt-3">
     <table class="table table-striped table-bordered">
       <thead>
         <tr>
           <th scope="col">{{ _('Column') }}</th>
           <th scope="col">{{ _('Label') }}</th>
+          <th scope="col">{{ _('Prefix') }}</th>
+          <th scope="col">{{ _('Suffix') }}</th>
         </tr>
       </thead>
         <tr>
@@ -90,6 +94,8 @@
             'checked' if '_id' in data.show_fields else '' }}
             />_id</label>
           </td>
+          <td></td>
+          <td></td>
           <td></td>
         </tr>
       {% for f in h.datastore_dictionary(resource.id) %}
@@ -108,10 +114,32 @@
               {{ f.get('info', {}).label }}
             {%- endblock -%}
           </td>
+          <td>
+            {%- if h.og_datatablesview_is_numeric_column(f.type) -%}
+            <input type="text" class="form-control dt-col-prefix"
+              data-colid="{{ f.id }}"
+              value="{{ column_prefixes.get(f.id, '') }}"
+              placeholder="{{ _('E.g. $') }}"
+              aria-label="{{ _('Prefix for') }} {{ f.id }}"
+              title="{{ _('Text to prepend to each value in this column (display only)') }}" />
+            {%- endif -%}
+          </td>
+          <td>
+            {%- if h.og_datatablesview_is_numeric_column(f.type) -%}
+            <input type="text" class="form-control dt-col-suffix"
+              data-colid="{{ f.id }}"
+              value="{{ column_suffixes.get(f.id, '') }}"
+              placeholder="{{ _('E.g. dollars') }}"
+              aria-label="{{ _('Suffix for') }} {{ f.id }}"
+              title="{{ _('Text to append to each value in this column (display only)') }}" />
+            {%- endif -%}
+          </td>
         </tr>
       {% endfor %}
     </table>
   </div>
+  <input type="hidden" name="column_prefixes" id="field-column_prefixes" />
+  <input type="hidden" name="column_suffixes" id="field-column_suffixes" />
 </div>
 
 <div class="form-group control-select">

--- a/ckanext/og_datatablesview/templates/og_datatables/datatables_view.html
+++ b/ckanext/og_datatablesview/templates/og_datatables/datatables_view.html
@@ -16,6 +16,8 @@
 <script type=text/javascript>
     const gdataDict = {{ datadictionary|tojson }}
     const gresviewId = '{{ resource_view.id }}'
+    const gcolumnPrefixes = {{ resource_view.get('column_prefixes', {})|tojson }}
+    const gcolumnSuffixes = {{ resource_view.get('column_suffixes', {})|tojson }}
 </script>
 
 <div id="resize_wrapper">

--- a/ckanext/og_datatablesview/tests/test_logic.py
+++ b/ckanext/og_datatablesview/tests/test_logic.py
@@ -1,7 +1,13 @@
 import pytest
 
 import ckan.plugins.toolkit as toolkit
+import ckan.lib.navl.dictization_functions as df
 from ckan.tests import factories
+from ckanext.og_datatablesview.plugin import (
+    og_datatables_column_prefixes,
+    og_datatables_column_suffixes,
+)
+from ckanext.og_datatablesview.helpers import og_datatablesview_is_numeric_column
 from ckanext.og_datatablesview.blueprint import (
     format_fts_query,
     build_filter_where_fragments,
@@ -368,6 +374,246 @@ class TestUtils:
         )
 
         assert response.get('hide_resource_info') == True
+
+
+    def test_og_datatableview_column_prefixes_dict_success(self):
+        """A dict of column prefixes round-trips through the view config"""
+        sysadmin = factories.Sysadmin()
+        dataset = factories.Dataset()
+        resource = factories.Resource(
+            package_id=dataset['id'],
+            format='CSV'
+        )
+        resource_view = factories.ResourceView(
+            resource_id=resource['id'],
+            title='OG Data Tables',
+            view_type='og_datatables_view',
+            column_prefixes={'amount': '$', 'total_fees': '$'}
+        )
+
+        response = toolkit.get_action('resource_view_show')(
+            {'user': sysadmin.get('name')},
+            {'id': resource_view.get('id')}
+        )
+
+        assert response.get('column_prefixes') == {
+            'amount': '$', 'total_fees': '$'
+        }
+
+
+    def test_og_datatableview_column_prefixes_default_empty_success(self):
+        """column_prefixes is absent/empty when not specified"""
+        sysadmin = factories.Sysadmin()
+        dataset = factories.Dataset()
+        resource = factories.Resource(
+            package_id=dataset['id'],
+            format='CSV'
+        )
+        resource_view = factories.ResourceView(
+            resource_id=resource['id'],
+            title='OG Data Tables',
+            view_type='og_datatables_view'
+        )
+
+        response = toolkit.get_action('resource_view_show')(
+            {'user': sysadmin.get('name')},
+            {'id': resource_view.get('id')}
+        )
+
+        assert not response.get('column_prefixes')
+
+
+    def test_og_datatableview_column_suffixes_dict_success(self):
+        """A dict of column suffixes round-trips through the view config"""
+        sysadmin = factories.Sysadmin()
+        dataset = factories.Dataset()
+        resource = factories.Resource(
+            package_id=dataset['id'],
+            format='CSV'
+        )
+        resource_view = factories.ResourceView(
+            resource_id=resource['id'],
+            title='OG Data Tables',
+            view_type='og_datatables_view',
+            column_suffixes={'amount': ' dollars', 'sq_feet': ' sqft'}
+        )
+
+        response = toolkit.get_action('resource_view_show')(
+            {'user': sysadmin.get('name')},
+            {'id': resource_view.get('id')}
+        )
+
+        assert response.get('column_suffixes') == {
+            'amount': ' dollars', 'sq_feet': ' sqft'
+        }
+
+
+    def test_og_datatableview_column_suffixes_default_empty_success(self):
+        """column_suffixes is absent/empty when not specified"""
+        sysadmin = factories.Sysadmin()
+        dataset = factories.Dataset()
+        resource = factories.Resource(
+            package_id=dataset['id'],
+            format='CSV'
+        )
+        resource_view = factories.ResourceView(
+            resource_id=resource['id'],
+            title='OG Data Tables',
+            view_type='og_datatables_view'
+        )
+
+        response = toolkit.get_action('resource_view_show')(
+            {'user': sysadmin.get('name')},
+            {'id': resource_view.get('id')}
+        )
+
+        assert not response.get('column_suffixes')
+
+
+    def test_og_datatableview_column_prefix_and_suffix_together_success(self):
+        """Prefix and suffix are stored independently on the same view"""
+        sysadmin = factories.Sysadmin()
+        dataset = factories.Dataset()
+        resource = factories.Resource(
+            package_id=dataset['id'],
+            format='CSV'
+        )
+        resource_view = factories.ResourceView(
+            resource_id=resource['id'],
+            title='OG Data Tables',
+            view_type='og_datatables_view',
+            column_prefixes={'amount': '$'},
+            column_suffixes={'amount': ' dollars'}
+        )
+
+        response = toolkit.get_action('resource_view_show')(
+            {'user': sysadmin.get('name')},
+            {'id': resource_view.get('id')}
+        )
+
+        assert response.get('column_prefixes') == {'amount': '$'}
+        assert response.get('column_suffixes') == {'amount': ' dollars'}
+
+
+class TestColumnPrefixesValidator:
+    """Unit tests for the og_datatables_column_prefixes validator"""
+
+    def test_missing_returns_empty(self):
+        assert og_datatables_column_prefixes(df.missing) == {}
+
+    def test_none_returns_empty(self):
+        assert og_datatables_column_prefixes(None) == {}
+
+    def test_empty_string_returns_empty(self):
+        assert og_datatables_column_prefixes('') == {}
+
+    def test_dict_passthrough(self):
+        assert og_datatables_column_prefixes({'amount': '$'}) == {'amount': '$'}
+
+    def test_json_string_decoded(self):
+        # this is how the config form POSTs the value
+        assert og_datatables_column_prefixes('{"amount": "$"}') == {'amount': '$'}
+
+    def test_json_string_and_dict_normalise_identically(self):
+        as_dict = og_datatables_column_prefixes({'a': '$', 'b': '#'})
+        as_json = og_datatables_column_prefixes('{"a": "$", "b": "#"}')
+        assert as_dict == as_json == {'a': '$', 'b': '#'}
+
+    def test_blank_prefixes_dropped(self):
+        assert og_datatables_column_prefixes(
+            {'a': '$', 'b': '', 'c': None}
+        ) == {'a': '$'}
+
+    def test_invalid_json_returns_empty(self):
+        assert og_datatables_column_prefixes('not json') == {}
+
+    def test_non_dict_json_returns_empty(self):
+        assert og_datatables_column_prefixes('[1, 2, 3]') == {}
+
+    def test_values_coerced_to_str(self):
+        assert og_datatables_column_prefixes({'a': 5}) == {'a': '5'}
+
+    def test_xss_payload_stored_verbatim(self):
+        # the validator stores the raw string; escaping happens at render time
+        payload = '<img src=x onerror=alert(1)>'
+        assert og_datatables_column_prefixes(
+            {'a': payload}
+        ) == {'a': payload}
+
+
+class TestColumnSuffixesValidator:
+    """Unit tests for the og_datatables_column_suffixes validator"""
+
+    def test_missing_returns_empty(self):
+        assert og_datatables_column_suffixes(df.missing) == {}
+
+    def test_none_returns_empty(self):
+        assert og_datatables_column_suffixes(None) == {}
+
+    def test_empty_string_returns_empty(self):
+        assert og_datatables_column_suffixes('') == {}
+
+    def test_dict_passthrough(self):
+        assert og_datatables_column_suffixes(
+            {'amount': ' dollars'}
+        ) == {'amount': ' dollars'}
+
+    def test_json_string_decoded(self):
+        # this is how the config form POSTs the value
+        assert og_datatables_column_suffixes(
+            '{"amount": " dollars"}'
+        ) == {'amount': ' dollars'}
+
+    def test_json_string_and_dict_normalise_identically(self):
+        as_dict = og_datatables_column_suffixes({'a': ' kg', 'b': '%'})
+        as_json = og_datatables_column_suffixes('{"a": " kg", "b": "%"}')
+        assert as_dict == as_json == {'a': ' kg', 'b': '%'}
+
+    def test_blank_suffixes_dropped(self):
+        assert og_datatables_column_suffixes(
+            {'a': ' kg', 'b': '', 'c': None}
+        ) == {'a': ' kg'}
+
+    def test_invalid_json_returns_empty(self):
+        assert og_datatables_column_suffixes('not json') == {}
+
+    def test_non_dict_json_returns_empty(self):
+        assert og_datatables_column_suffixes('[1, 2, 3]') == {}
+
+    def test_values_coerced_to_str(self):
+        assert og_datatables_column_suffixes({'a': 5}) == {'a': '5'}
+
+    def test_xss_payload_stored_verbatim(self):
+        # the validator stores the raw string; escaping happens at render time
+        payload = '<img src=x onerror=alert(1)>'
+        assert og_datatables_column_suffixes(
+            {'a': payload}
+        ) == {'a': payload}
+
+
+class TestIsNumericColumn:
+    """Unit tests for the og_datatablesview_is_numeric_column helper"""
+
+    @pytest.mark.parametrize('field_type', [
+        'numeric', 'number', 'decimal', 'money',
+        'int', 'integer', 'smallint', 'bigint',
+        'int2', 'int4', 'int8',
+        'float', 'float4', 'float8', 'real', 'double precision',
+    ])
+    def test_numeric_types_true(self, field_type):
+        assert og_datatablesview_is_numeric_column(field_type) is True
+
+    def test_case_insensitive(self):
+        assert og_datatablesview_is_numeric_column('Int8') is True
+        assert og_datatablesview_is_numeric_column('NUMERIC') is True
+        assert og_datatablesview_is_numeric_column('MONEY') is True
+
+    @pytest.mark.parametrize('field_type', [
+        'text', 'timestamp', 'timestamptz', 'date', 'bool', 'json',
+        '', None,
+    ])
+    def test_non_numeric_types_false(self, field_type):
+        assert og_datatablesview_is_numeric_column(field_type) is False
 
 
 class TestFormatFtsQuery:


### PR DESCRIPTION
## Summary

Adds an optional per-column **display prefix** and **suffix** to the Data Table view, so admins can render values like `$1,234 dollars` for an amount column. Both affixes are **display-only** — sorting, searching, and file exports (CSV/TSV/JSON/XML) keep the raw underlying values.

The option is offered only for columns whose datastore type is numeric.

## What changed

- **Storage**: affixes are stored in the view config as `{column_id: text}` maps (`column_prefixes` / `column_suffixes`). A shared normaliser accepts both a dict (API/tests) and a JSON string (the raw value POSTed by the config form), drops blank entries, and coerces values to strings.
- **Config form**: a Prefix and Suffix text input per column, shown only for numeric columns (`og_datatablesview_is_numeric_column`). Inputs are serialized into hidden `column_prefixes` / `column_suffixes` fields on submit. Placeholders (`E.g. $`, `E.g. dollars`) hint at expected input.
- **Rendering**: the DataTables cell render callback prepends/appends the affixes. Values are escaped via the existing `esc()` helper and only the `'display'` type is touched, so ordering/search data and the raw values are untouched.
- **Both plugins**: mirrored across `og_datatablesview` and `og_datatables_datefilterview`.

## Security

- Affix strings are escaped with `esc()` before insertion into cell HTML (rendered as text, not markup).
- `|tojson` guards the transport into the inline `<script>`.
- Validators store values verbatim (escaping is deferred to render time); XSS-payload tests lock this in.
- Affixes never reach datastore SQL — `blueprint.py` is untouched.

## Testing

- Unit tests for both validators (dict/JSON-string parity, blank-dropping, invalid JSON, str coercion, XSS payload).
- Parametrized tests for the numeric-type helper (numeric types true; text/date/empty/None false; case-insensitive).
- Config round-trip tests (`resource_view_show`) for prefixes, suffixes, and both together.
- Full `test_logic.py` suite passes (110 tests). JS render logic and escaping verified separately; all edited JS passes `node --check`.

## Notes

- The numeric-only restriction is enforced in the config form UI. A prefix/suffix set directly via the API on a non-numeric column would still render — intentional and out of scope.
- `test.ini` is intentionally excluded from this PR (it carries an unrelated local change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)