### PR TITLE
Hide Prefix/Suffix columns when resource has no numeric columns

### DIFF
--- a/ckanext/og_datatables_datefilterview/helpers.py
+++ b/ckanext/og_datatables_datefilterview/helpers.py
@@ -28,6 +28,21 @@ def og_datatablesview_is_numeric_column(field_type: Any) -> bool:
     return str(field_type or '').lower() in NUMERIC_COLUMN_TYPES
 
 
+def og_datatablesview_has_numeric_column(fields: Any) -> bool:
+    """
+    Return True if any field in the given data dictionary list is numeric.
+
+    Used by the config form to hide the Prefix/Suffix columns entirely when a
+    resource has no numeric columns (so they are not shown as empty columns).
+    """
+    if not fields:
+        return False
+    return any(
+        og_datatablesview_is_numeric_column(f.get('type'))
+        for f in fields
+    )
+
+
 def _og_datatablesview_column_affixes(value: Any) -> dict[str, str]:
     """
     Normalise a per-column affix map (prefixes or suffixes) into a

--- a/ckanext/og_datatables_datefilterview/plugin.py
+++ b/ckanext/og_datatables_datefilterview/plugin.py
@@ -176,6 +176,7 @@ class OG_DataTablesDateFilterView(p.SingletonPlugin):
             'og_datatablesview_column_prefixes': helpers.og_datatablesview_column_prefixes,
             'og_datatablesview_column_suffixes': helpers.og_datatablesview_column_suffixes,
             'og_datatablesview_is_numeric_column': helpers.og_datatablesview_is_numeric_column,
+            'og_datatablesview_has_numeric_column': helpers.og_datatablesview_has_numeric_column,
         }
 
 

--- a/ckanext/og_datatables_datefilterview/templates/og_datatables_datefilterview/datatables_form.html
+++ b/ckanext/og_datatables_datefilterview/templates/og_datatables_datefilterview/datatables_form.html
@@ -73,14 +73,18 @@
   </div>
   {% set column_prefixes = h.og_datatablesview_column_prefixes(data.get('column_prefixes')) %}
   {% set column_suffixes = h.og_datatablesview_column_suffixes(data.get('column_suffixes')) %}
+  {% set dt_fields = h.datastore_dictionary(resource.id) %}
+  {% set show_affixes = h.og_datatablesview_has_numeric_column(dt_fields) %}
   <div class="controls dt-select-columns mt-3">
     <table class="table table-striped table-bordered">
       <thead>
         <tr>
           <th scope="col">{{ _('Column') }}</th>
           <th scope="col">{{ _('Label') }}</th>
+          {% if show_affixes %}
           <th scope="col">{{ _('Prefix') }}</th>
           <th scope="col">{{ _('Suffix') }}</th>
+          {% endif %}
         </tr>
       </thead>
         <tr>
@@ -95,10 +99,12 @@
             />_id</label>
           </td>
           <td></td>
+          {% if show_affixes %}
           <td></td>
           <td></td>
+          {% endif %}
         </tr>
-      {% for f in h.datastore_dictionary(resource.id) %}
+      {% for f in dt_fields %}
         <tr>
           <td>
             <label class="checkbox">
@@ -114,6 +120,7 @@
               {{ f.get('info', {}).label }}
             {%- endblock -%}
           </td>
+          {% if show_affixes %}
           <td>
             {%- if h.og_datatablesview_is_numeric_column(f.type) -%}
             <input type="text" class="form-control dt-col-prefix"
@@ -134,6 +141,7 @@
               title="{{ _('Text to append to each value in this column (display only)') }}" />
             {%- endif -%}
           </td>
+          {% endif %}
         </tr>
       {% endfor %}
     </table>

--- a/ckanext/og_datatablesview/helpers.py
+++ b/ckanext/og_datatablesview/helpers.py
@@ -28,6 +28,21 @@ def og_datatablesview_is_numeric_column(field_type: Any) -> bool:
     return str(field_type or '').lower() in NUMERIC_COLUMN_TYPES
 
 
+def og_datatablesview_has_numeric_column(fields: Any) -> bool:
+    """
+    Return True if any field in the given data dictionary list is numeric.
+
+    Used by the config form to hide the Prefix/Suffix columns entirely when a
+    resource has no numeric columns (so they are not shown as empty columns).
+    """
+    if not fields:
+        return False
+    return any(
+        og_datatablesview_is_numeric_column(f.get('type'))
+        for f in fields
+    )
+
+
 def _og_datatablesview_column_affixes(value: Any) -> dict[str, str]:
     """
     Normalise a per-column affix map (prefixes or suffixes) into a

--- a/ckanext/og_datatablesview/plugin.py
+++ b/ckanext/og_datatablesview/plugin.py
@@ -176,6 +176,7 @@ class OG_DataTablesView(p.SingletonPlugin):
             'og_datatablesview_column_prefixes': helpers.og_datatablesview_column_prefixes,
             'og_datatablesview_column_suffixes': helpers.og_datatablesview_column_suffixes,
             'og_datatablesview_is_numeric_column': helpers.og_datatablesview_is_numeric_column,
+            'og_datatablesview_has_numeric_column': helpers.og_datatablesview_has_numeric_column,
         }
 
 

--- a/ckanext/og_datatablesview/templates/og_datatables/datatables_form.html
+++ b/ckanext/og_datatablesview/templates/og_datatables/datatables_form.html
@@ -73,14 +73,18 @@
   </div>
   {% set column_prefixes = h.og_datatablesview_column_prefixes(data.get('column_prefixes')) %}
   {% set column_suffixes = h.og_datatablesview_column_suffixes(data.get('column_suffixes')) %}
+  {% set dt_fields = h.datastore_dictionary(resource.id) %}
+  {% set show_affixes = h.og_datatablesview_has_numeric_column(dt_fields) %}
   <div class="controls dt-select-columns mt-3">
     <table class="table table-striped table-bordered">
       <thead>
         <tr>
           <th scope="col">{{ _('Column') }}</th>
           <th scope="col">{{ _('Label') }}</th>
+          {% if show_affixes %}
           <th scope="col">{{ _('Prefix') }}</th>
           <th scope="col">{{ _('Suffix') }}</th>
+          {% endif %}
         </tr>
       </thead>
         <tr>
@@ -95,10 +99,12 @@
             />_id</label>
           </td>
           <td></td>
+          {% if show_affixes %}
           <td></td>
           <td></td>
+          {% endif %}
         </tr>
-      {% for f in h.datastore_dictionary(resource.id) %}
+      {% for f in dt_fields %}
         <tr>
           <td>
             <label class="checkbox">
@@ -114,6 +120,7 @@
               {{ f.get('info', {}).label }}
             {%- endblock -%}
           </td>
+          {% if show_affixes %}
           <td>
             {%- if h.og_datatablesview_is_numeric_column(f.type) -%}
             <input type="text" class="form-control dt-col-prefix"
@@ -134,6 +141,7 @@
               title="{{ _('Text to append to each value in this column (display only)') }}" />
             {%- endif -%}
           </td>
+          {% endif %}
         </tr>
       {% endfor %}
     </table>

--- a/ckanext/og_datatablesview/tests/test_logic.py
+++ b/ckanext/og_datatablesview/tests/test_logic.py
@@ -7,7 +7,10 @@ from ckanext.og_datatablesview.plugin import (
     og_datatables_column_prefixes,
     og_datatables_column_suffixes,
 )
-from ckanext.og_datatablesview.helpers import og_datatablesview_is_numeric_column
+from ckanext.og_datatablesview.helpers import (
+    og_datatablesview_is_numeric_column,
+    og_datatablesview_has_numeric_column,
+)
 from ckanext.og_datatablesview.blueprint import (
     format_fts_query,
     build_filter_where_fragments,
@@ -614,6 +617,40 @@ class TestIsNumericColumn:
     ])
     def test_non_numeric_types_false(self, field_type):
         assert og_datatablesview_is_numeric_column(field_type) is False
+
+
+class TestHasNumericColumn:
+    """Unit tests for the og_datatablesview_has_numeric_column helper"""
+
+    def test_true_when_any_field_numeric(self):
+        fields = [
+            {'id': 'name', 'type': 'text'},
+            {'id': 'amount', 'type': 'numeric'},
+        ]
+        assert og_datatablesview_has_numeric_column(fields) is True
+
+    def test_true_with_postgres_type_name(self):
+        assert og_datatablesview_has_numeric_column(
+            [{'id': 'n', 'type': 'int4'}]
+        ) is True
+
+    def test_false_when_all_text(self):
+        fields = [
+            {'id': 'name', 'type': 'text'},
+            {'id': 'city', 'type': 'text'},
+            {'id': 'created', 'type': 'timestamp'},
+        ]
+        assert og_datatablesview_has_numeric_column(fields) is False
+
+    def test_false_for_empty_list(self):
+        assert og_datatablesview_has_numeric_column([]) is False
+
+    def test_false_for_none(self):
+        assert og_datatablesview_has_numeric_column(None) is False
+
+    def test_field_without_type_key(self):
+        # a malformed field dict should not blow up
+        assert og_datatablesview_has_numeric_column([{'id': 'x'}]) is False
 
 
 class TestFormatFtsQuery:


### PR DESCRIPTION
## Summary

Follow-up to #23. The prefix/suffix inputs are only offered for numeric columns, but the config form always rendered the **Prefix** and **Suffix** table headers. On a resource with **no numeric columns**, this showed two entirely empty columns — which confused users during testing (they read as broken, not "not applicable").

Now the Prefix/Suffix header cells and their per-row cells are only rendered when the resource has at least one numeric column. Mixed resources are unchanged: inputs on numeric rows, blank cells on non-numeric rows.

## What changed

- **New helper** `og_datatablesview_has_numeric_column(fields)` (reuses the existing `og_datatablesview_is_numeric_column`), registered as a template helper in both plugins.
- **Config form**: gate the affix `<th>` headers, the `_id`-row empty cells, and the per-row affix `<td>` cells on `show_affixes`. The data dictionary is captured once (`dt_fields`) to avoid a duplicate `datastore_dictionary` call.
- **Both plugins**: mirrored across `og_datatablesview` and `og_datatables_datefilterview`.

Presentation-only — no changes to the validators, hidden fields, form JS, view template, or render JS.

## Testing

- Full `test_logic.py` suite passes (116 tests; +6 for the new `TestHasNumericColumn`: numeric present, postgres type name, all-text, empty list, `None`, malformed field without a `type` key).
- Form-render tests confirm both cases: all-text resource → no Prefix/Suffix headers or inputs; mixed resource → headers present with exactly one prefix and one suffix input (numeric row only).

## Notes

- `test.ini` is intentionally excluded (unrelated local change).
- Open product question raised separately: whether to allow affixes on non-numeric columns (e.g. numbers stored as `text`). Out of scope for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)